### PR TITLE
Allow app to be built from already packaged ASAR

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,8 @@ var args = require('minimist')(process.argv.slice(2), {boolean: ['prune', 'asar'
 var packager = require('./')
 var usage = fs.readFileSync(__dirname + '/usage.txt').toString()
 
-args.dir = args._[0]
+if (fs.statSync(args._[0]).isDirectory()) args.dir = args._[0]
+else args['asar-package'] = args._[0]
 args.name = args._[1]
 
 var protocolSchemes = [].concat(args.protocol || [])
@@ -16,7 +17,7 @@ if (protocolSchemes && protocolNames && protocolNames.length === protocolSchemes
   })
 }
 
-if (!args.dir || !args.name || !args.version || (!args.all && (!args.platform || !args.arch))) {
+if (!(args.dir || args['asar-package']) || !args.name || !args.version || (!args.all && (!args.platform || !args.arch))) {
   console.error(usage)
   process.exit(1)
 }

--- a/common.js
+++ b/common.js
@@ -79,7 +79,8 @@ module.exports = {
         ncp(templatePath, tempPath, cb)
       },
       function (cb) {
-        ncp(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: true}, cb)
+        if (opts.dir) ncp(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: true}, cb)
+        else ncp(opts['asar-package'], path.join(appPath, '..', 'app.asar'), cb)
       }
     ]
 
@@ -91,7 +92,7 @@ module.exports = {
       })
     }
 
-    if (opts.asar) {
+    if (opts.asar && opts.dir) {
       operations.push(function (cb) {
         asarApp(path.join(appPath), cb)
       })

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ npm i electron-packager -g
 ### usage
 
 ```
-Usage: electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch> --version=<version>
+Usage: electron-packager <sourcedir | source ASAR> <appname> --platform=<platform> --arch=<arch> --version=<version>
   
 Required options
 
@@ -78,8 +78,8 @@ packager(opts, function done (err, appPath) { })
 
 ##### opts
 **Required**  
-`dir` - *String*  
-The source directory.
+`dir` or `asar-package` - *String*  
+The source directory or path to source ASAR. One of the two required.
 
 `name` - *String*  
 The application name.

--- a/usage.txt
+++ b/usage.txt
@@ -1,4 +1,4 @@
-Usage: electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch> --version=<version>
+Usage: electron-packager <sourcedir | source ASAR> <appname> --platform=<platform> --arch=<arch> --version=<version>
 
 Required options
 


### PR DESCRIPTION
This PR allows apps to be built from pre-packaged ASAR's.
The way it works with the CLI is simple: just pass the ASAR in place of the directory.
For programmatic usage, use "asar-package" arg.

Useful when building for a few platforms at once :)