### PR TITLE
Automatically ignoring --out path

### DIFF
--- a/common.js
+++ b/common.js
@@ -32,7 +32,12 @@ function generateFinalPath (opts) {
 function userIgnoreFilter (opts) {
   var ignore = opts.ignore || []
   if (!Array.isArray(ignore)) ignore = [ignore]
-  if (opts.out && opts.out.indexOf('./') === 0) ignore.push('^/' + opts.out.substr(2))
+  if (opts.out) {
+    var out = path.join(process.cwd(), opts.out)
+    if (out.indexOf(process.cwd()) === 0) {
+      ignore.push('^' + out.substr(process.cwd().length))
+    }
+  }
   return function filter (file) {
     file = file.split(path.resolve(opts.dir))[1]
 

--- a/common.js
+++ b/common.js
@@ -30,6 +30,9 @@ function generateFinalPath (opts) {
 }
 
 function userIgnoreFilter (opts) {
+  var ignore = opts.ignore || []
+  if (!Array.isArray(ignore)) ignore = [ignore]
+  if (opts.out && opts.out.indexOf('./') === 0) ignore.push('^/' + opts.out.substr(2))
   return function filter (file) {
     file = file.split(path.resolve(opts.dir))[1]
 
@@ -38,8 +41,6 @@ function userIgnoreFilter (opts) {
       file = file.replace(/\\/g, '/')
     }
 
-    var ignore = opts.ignore || []
-    if (!Array.isArray(ignore)) ignore = [ignore]
     for (var i = 0; i < ignore.length; i++) {
       if (file.match(ignore[i])) {
         return false


### PR DESCRIPTION
Fixes #120.

If the output directory is nested within the directory that gets packed (ie: starts with `./`), any files within it area ignored during the `electron-packager` process.  Also moved the `var ignore...` out of the function so it's not run every time the filter is called for a small performance gain.