### PR TITLE
Make version parameter optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ function createSeries (opts, archs, platforms) {
                 })
               } else {
                 console.error('Skipping ' + platform + ' ' + arch +
-                    ' (output dir already exists, use --overwrite to force)')
+                  ' (output dir already exists, use --overwrite to force)')
                 callback()
               }
             } else {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var series = require('run-series')
 var resolve = require('resolve')
+var latestVersion = require('latest-version')
 var getPackageInfo = require('get-package-info')
 var common = require('./common')
 
@@ -152,7 +153,7 @@ function createSeries (opts, archs, platforms) {
                 })
               } else {
                 console.error('Skipping ' + platform + ' ' + arch +
-                  ' (output dir already exists, use --overwrite to force)')
+                    ' (output dir already exists, use --overwrite to force)')
                 callback()
               }
             } else {
@@ -176,6 +177,22 @@ function createSeries (opts, archs, platforms) {
   }))
 }
 
+function ignoreAndCreateSeries (opts, archs, platforms, cb) {
+  // Ignore this and related modules by default
+  var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\.git($|/)', '/node_modules/\\.bin($|/)']
+  if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
+  opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
+
+  series(createSeries(opts, archs, platforms), function (err, appPaths) {
+    if (err) return cb(err)
+
+    cb(null, appPaths.filter(function (appPath) {
+      // Remove falsy entries (e.g. skipped platforms)
+      return appPath
+    }))
+  })
+}
+
 module.exports = function packager (opts, cb) {
   var archs = validateList(opts.all ? 'all' : opts.arch, supportedArchs, 'arch')
   var platforms = validateList(opts.all ? 'all' : opts.platform, supportedPlatforms, 'platform')
@@ -184,22 +201,15 @@ module.exports = function packager (opts, cb) {
 
   getNameAndVersion(opts, opts.dir || process.cwd(), function (err) {
     if (err) {
-      err.message = 'Unable to infer name or version. Please specify a name and version.\n' + err.message
-      return cb(err)
+      // get the latest version of electron-prebuilt from the web
+      latestVersion('electron-prebuilt').then(function (version) {
+        opts.version = version
+        ignoreAndCreateSeries(opts, archs, platforms, cb)
+      }).catch(function (err) {
+        return cb('Unable to determine latest electron version, please specify it. \n' + err)
+      })
+    } else {
+      ignoreAndCreateSeries(opts, archs, platforms, cb)
     }
-    // Ignore this and related modules by default
-    var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\.git($|/)', '/node_modules/\\.bin($|/)']
-    if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
-    opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
-
-    series(createSeries(opts, archs, platforms), function (err, appPaths) {
-      if (err) return cb(err)
-
-      cb(null, appPaths.filter(function (appPath) {
-        // Remove falsy entries (e.g. skipped platforms)
-        return appPath
-      }))
-    })
   })
-
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "electron-download": "^1.0.0",
     "extract-zip": "^1.0.3",
     "get-package-info": "0.0.2",
+    "latest-version": "^2.0.0",
     "minimist": "^1.1.1",
     "mkdirp": "^0.5.0",
     "mv": "^2.0.3",

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ npm install electron-packager -g
 Running electron-packager from the command line has this basic form:
 
 ```
-electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch> --version=<Electron version> [optional flags...]
+electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch> [optional flags...]
 ```
 
 This will:
@@ -206,7 +206,7 @@ If the file extension is omitted, it is auto-completed to the correct extension 
 
 `version` - *String*
 
-  The Electron version with which the app is built (without the leading 'v') - for example, [`0.33.9`](https://github.com/atom/electron/releases/tag/v0.33.9). See [Electron releases](https://github.com/atom/electron/releases) for valid versions. If omitted, it will use the version of the nearest local installation of electron-prebuilt.
+  The Electron version with which the app is built (without the leading 'v') - for example, [`0.33.9`](https://github.com/atom/electron/releases/tag/v0.33.9). See [Electron releases](https://github.com/atom/electron/releases) for valid versions. If omitted, it will use the version of the nearest local installation of electron-prebuilt or fall back to the latest version of electron-prebuilt on npm.
 
 `version-string` - *Object*
 

--- a/usage.txt
+++ b/usage.txt
@@ -1,12 +1,11 @@
-Usage: electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch> --version=<Electron version>
+Usage: electron-packager <sourcedir> <appname> --platform=<platform> --arch=<arch>
 
 Required options
 
 platform           all, or one or more of: linux, win32, darwin (comma-delimited if multiple)
 arch               all, ia32, x64
-version            the version of Electron that is being packaged, see https://github.com/atom/electron/releases
 
-Example            electron-packager ./ FooBar --platform=darwin --arch=x64 --version=0.28.2
+Example            electron-packager ./ FooBar --platform=darwin --arch=x64
 
 Optional options
 
@@ -30,6 +29,7 @@ prune              runs `npm prune --production` on the app
 sign               should contain the identity to be used when running `codesign` (only for building for the darwin platform, on OS X)
 strict-ssl         whether SSL certificates are required to be valid when downloading Electron.
                    It defaults to true, use --strict-ssl=false to disable checks.
+version            the version of Electron that is being packaged, see https://github.com/atom/electron/releases
 version-string     should contain a hash of the application metadata to be embedded into the executable (win32 platform only).
                    These can be specified on the command line via dot notation,
                    e.g. --version-string.CompanyName="Company Inc." --version-string.ProductName="Product"


### PR DESCRIPTION
The readme states that the if I'm using the programmatic api, the `version` argument is optional.

> version - String
> The Electron version with which the app is built (without the leading 'v') - for example, 0.33.9. See Electron releases for valid versions. If omitted, it will use the version of the nearest local installation of electron-prebuilt.

I realised that if I do not run have a local installation of `electron-prebuilt`, an error will be thrown. Instead of this behaviour, I think it would be simpler for the user if the module makes a query to determine the latest version of electron and use that directly if it is not specified. I've made this implementation in my change, and at the same time, a positive side effect would be that the `--version` command line flag is also an optional parameter.
