### PR TITLE
Ability to set tmpdir to false to disable using temp directory

### DIFF
--- a/common.js
+++ b/common.js
@@ -50,8 +50,19 @@ function userIgnoreFilter (opts) {
   }
 
   var normalizedOut = opts.out ? path.resolve(opts.out) : null
+  var outIgnores = []
+  if (normalizedOut === null || normalizedOut === process.cwd()) {
+    ['darwin', 'linux', 'win32'].forEach(function (platform) {
+      ['ia32', 'x64'].forEach(function (arch) {
+        outIgnores.push(path.join(process.cwd(), opts.name + '-' + platform + '-' + arch))
+      })
+    })
+  } else {
+    outIgnores.push(normalizedOut)
+  }
+
   return function filter (file) {
-    if (normalizedOut === file) {
+    if (outIgnores.indexOf(file) !== -1) {
       return false
     }
 

--- a/common.js
+++ b/common.js
@@ -49,7 +49,12 @@ function userIgnoreFilter (opts) {
     }
   }
 
+  var normalizedOut = opts.out ? path.resolve(opts.out) : null
   return function filter (file) {
+    if (normalizedOut === file) {
+      return false
+    }
+
     var name = file.split(path.resolve(opts.dir))[1]
 
     if (path.sep === '\\') {

--- a/common.js
+++ b/common.js
@@ -9,6 +9,9 @@ var ncp = require('ncp').ncp
 var rimraf = require('rimraf')
 var series = require('run-series')
 
+var archs = ['ia32', 'x64']
+var platforms = ['darwin', 'linux', 'mas', 'win32']
+
 function asarApp (appPath, asarOptions, cb) {
   var src = path.join(appPath)
   var dest = path.join(appPath, '..', 'app.asar')
@@ -52,8 +55,8 @@ function userIgnoreFilter (opts) {
   var normalizedOut = opts.out ? path.resolve(opts.out) : null
   var outIgnores = []
   if (normalizedOut === null || normalizedOut === process.cwd()) {
-    ['darwin', 'linux', 'win32'].forEach(function (platform) {
-      ['ia32', 'x64'].forEach(function (arch) {
+    platforms.forEach(function (platform) {
+      archs.forEach(function (arch) {
         outIgnores.push(path.join(process.cwd(), opts.name + '-' + platform + '-' + arch))
       })
     })
@@ -78,6 +81,9 @@ function userIgnoreFilter (opts) {
 }
 
 module.exports = {
+  archs: archs,
+  platforms: platforms,
+
   generateFinalPath: generateFinalPath,
 
   initializeApp: function initializeApp (opts, templatePath, appRelativePath, callback) {

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ var resolve = require('resolve')
 var getPackageInfo = require('get-package-info')
 var common = require('./common')
 
-var supportedArchs = {
-  ia32: 1,
-  x64: 1
-}
+var supportedArchs = common.archs.reduce(function (result, arch) {
+  result[arch] = 1
+  return result
+}, {})
 
 var supportedPlatforms = {
   // Maps to module ID for each platform (lazy-required if used)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "coveralls": "^2.11.6",
     "nyc": "^5.6.0",
+    "object-assign": "^4.0.1",
     "rcinfo": "^0.1.3",
     "run-waterfall": "^1.1.1",
     "standard": "^5.4.1",

--- a/readme.md
+++ b/readme.md
@@ -209,7 +209,7 @@ If the file extension is omitted, it is auto-completed to the correct extension 
 
 `ignore` - *RegExp* or *Function*
 
-  A pattern which specifies which files to ignore when copying files to create the package(s). Alternatively, this can be a predicate function that, given the file path, returns true if the file should be ignored or false if the file should be kept.
+  A pattern which specifies which files to ignore when copying files to create the package(s). `out` directory is ignored by default. Alternatively, this can be a predicate function that, given the file path, returns true if the file should be ignored or false if the file should be kept.
 
 `name` - *String*
   The application name. If omitted, it will use the "productName" or "name" of the nearest package.json.

--- a/test/basic.js
+++ b/test/basic.js
@@ -25,11 +25,10 @@ function generateNamePath (opts) {
   return opts.name + (opts.platform === 'win32' ? '.exe' : '')
 }
 
-function createDefaultsTest (combination) {
+function createDefaultsTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
 
@@ -83,11 +82,10 @@ function createDefaultsTest (combination) {
   }
 }
 
-function createOutTest (combination) {
+function createOutTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.out = 'dist'
@@ -115,11 +113,10 @@ function createOutTest (combination) {
   }
 }
 
-function createAsarTest (combination) {
+function createAsarTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.asar = true
@@ -160,11 +157,10 @@ function createAsarTest (combination) {
   }
 }
 
-function createPruneTest (combination) {
+function createPruneTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.prune = true
@@ -198,11 +194,10 @@ function createPruneTest (combination) {
   }
 }
 
-function createIgnoreTest (combination, ignorePattern, ignoredFile) {
+function createIgnoreTest (opts, ignorePattern, ignoredFile) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.ignore = ignorePattern
@@ -228,11 +223,10 @@ function createIgnoreTest (combination, ignorePattern, ignoredFile) {
   }
 }
 
-function createOverwriteTest (combination) {
+function createOverwriteTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout * 2) // Multiplied since this test packages the application twice
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
 
@@ -272,13 +266,12 @@ function createOverwriteTest (combination) {
   }
 }
 
-function createInferTest (combination) {
+function createInferTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
     // Don't specify name or version
-    delete combination.version
-    var opts = Object.create(combination)
+    delete opts.version
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
 
     var finalPath
@@ -315,11 +308,10 @@ function createInferTest (combination) {
   }
 }
 
-function createTmpdirTest (combination) {
+function createTmpdirTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.out = 'dist'
@@ -341,13 +333,11 @@ function createTmpdirTest (combination) {
   }
 }
 
-function createIgnoreOutDirTest (combination, distPath) {
+function createIgnoreOutDirTest (opts, distPath) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
-    opts.version = combination.version
 
     var appDir = util.getWorkCwd()
     opts.dir = appDir
@@ -384,13 +374,11 @@ function createIgnoreOutDirTest (combination, distPath) {
   }
 }
 
-function createIgnoreImplicitOutDirTest (combination) {
+function createIgnoreImplicitOutDirTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(combination)
     opts.name = 'basicTest'
-    opts.version = combination.version
 
     var appDir = util.getWorkCwd()
     opts.dir = appDir

--- a/test/util.js
+++ b/test/util.js
@@ -6,6 +6,7 @@ var download = require('electron-download')
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var series = require('run-series')
+var objectAssign = require('object-assign')
 
 var ORIGINAL_CWD = process.cwd()
 var WORK_CWD = path.join(__dirname, 'work')
@@ -102,7 +103,7 @@ exports.testAllPlatforms = function testAllPlatforms (name, createTest /*, ...cr
   exports.setup()
   exports.forEachCombination(function (combination) {
     test(name + ': ' + combination.platform + '-' + combination.arch,
-      createTest.apply(null, [combination].concat(args)))
+      createTest.apply(null, [objectAssign({}, combination)].concat(args)))
   })
   exports.teardown()
 }

--- a/test/util.js
+++ b/test/util.js
@@ -11,18 +11,17 @@ var objectAssign = require('object-assign')
 var ORIGINAL_CWD = process.cwd()
 var WORK_CWD = path.join(__dirname, 'work')
 
-var archs = ['ia32', 'x64']
-var platforms = ['darwin', 'linux', 'mas', 'win32']
 var slice = Array.prototype.slice
 var version = require('./config.json').version
+var common = require('../common')
 
 function isPlatformMac (platform) {
   return platform === 'darwin' || platform === 'mas'
 }
 
 var combinations = []
-archs.forEach(function (arch) {
-  platforms.forEach(function (platform) {
+common.archs.forEach(function (arch) {
+  common.platforms.forEach(function (platform) {
     // Electron does not have 32-bit releases for Mac OS X, so skip that combination
     // Also skip testing darwin/mas target on Windows since electron-packager itself skips it
     // (see https://github.com/electron-userland/electron-packager/issues/71)

--- a/test/win32.js
+++ b/test/win32.js
@@ -1,5 +1,6 @@
 var fs = require('fs')
 var path = require('path')
+var objectAssign = require('object-assign')
 
 var packager = require('..')
 var test = require('tape')
@@ -23,10 +24,7 @@ function generateVersionStringTest (metadata_property, extra_opts, expected_valu
     t.timeoutAfter(config.timeout)
 
     var appExePath
-    var opts = Object.create(baseOpts)
-    for (var opt_key in extra_opts) {
-      opts[opt_key] = extra_opts[opt_key]
-    }
+    var opts = objectAssign({}, baseOpts, extra_opts)
 
     waterfall([
       function (cb) {


### PR DESCRIPTION
I use electron-packager programmatically in [electron-complete-builder](https://github.com/develar/electron-complete-builder).

Currently, electron-packager cannot be used in parallel —my tests failed (I use [ava](https://github.com/sindresorhus/ava)). Because electron-packager uses one predefined temp directory instead of random — `path.join(opts.tmpdir || os.tmpdir(), 'electron-packager')`

This pull request doesn't fix it. Instead, I ask you ability to disable using of temp dir. And just use specified   `out` directly.

Why?
* If you use programmatically, you maybe already manage temp dir. For example, temp dir and out dir management (overwrite check) is not required for `electron-complete-builder` — it is already implemented on my side. 
* In tests, you have to copy project directory to temp in any case (if you run tests in parallel), so, yet another temp directory just add complexity and slowdown.