### PR TITLE
Add `extend-info` and `extra-resource` arguments for creating the Mac application package.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,14 @@ packager(opts, function done (err, appPath) { })
 
   The directory where prebuilt, pre-packaged Electron downloads are cached. Defaults to `$HOME/.electron`.
 
+`extend-info` - *String*
+
+  Filename of a plist file; the contents are added to the app's plist. Entries in `extend-info` override entries in the base plist file supplied by electron-prebuilt, but are overridden by other explicit arguments such as `app-version` or `app-bundle-id`. (OS X only)
+
+`extra-resource` - *String* or *Array*
+
+  Filename of a file to be copied directly into the app's `Contents/Resources` directory. (OS X only)
+
 `helper-bundle-id` - *String*
 
   The bundle identifier to use in the application helper's plist (OS X only).

--- a/test/fixtures/data1.txt
+++ b/test/fixtures/data1.txt
@@ -1,0 +1,1 @@
+This is a text file.

--- a/test/fixtures/extrainfo.plist
+++ b/test/fixtures/extrainfo.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleVersion</key>
+    <string>0.0.0</string>
+    <key>CFBundleIdentifier</key>
+    <string>x.y.z.z.y</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
+    <key>TestKeyString</key>
+    <string>String data</string>
+    <key>TestKeyBool</key>
+    <true/>
+    <key>TestKeyInt</key>
+    <integer>12345</integer>
+    <key>TestKeyArray</key>
+    <array>
+      <string>public.content</string>
+      <string>public.data</string>
+    </array>
+    <key>TestKeyDict</key>
+    <dict>
+      <key>Number</key>
+      <integer>98765</integer>
+      <key>CFBundleVersion</key>
+      <string>0.0.0</string>
+    </dict>
+  </dict>
+</plist>

--- a/usage.txt
+++ b/usage.txt
@@ -21,6 +21,8 @@ asar-unpack-dir    unpacks the dir to app.asar.unpacked directory whose names ma
                    For example, `--asar-unpack-dir=sub_dir` will unpack the directory `/<sourcedir>/sub_dir`.
 build-version      build version to set for the app (darwin/mas platform only)
 cache              directory of cached Electron downloads. Defaults to '$HOME/.electron'
+extend-info        a plist file to append to the app plist (darwin/mas platform only)
+extra-resource     a file to copy into the app's Contents/Resources (darwin/mas platform only)
 helper-bundle-id   bundle identifier to use in the app helper plist (darwin/mas platform only)
 icon               the icon file to use as the icon for the app. Note: Format depends on platform.
 ignore             do not copy files into app whose filenames regex .match this string


### PR DESCRIPTION
It is useful to be able to set *arbitrary* fields in the plist file. MacOS documents many keys, and it's unreasonable to define a separate electron-packager argument for each one. Some keys also need large array or dict structures, which can't comfortably be specified on the command line or in a package script.

Therefore, we want to be able to specify a plist file and merge its contents into the app Info.plist.

We may also need to install files directly into the app's Contents/Resources directory. For example, `UTExportedTypeDeclarations` may specify an icon for a document type; the icon should be an .icns file in Contents/Resources.

Therefore, two new arguments:

`extend-info`: Take the filename of a plist file and extend Info.plist with its contents. Other explicit arguments such as `app-bundle-id` override this.

`extra-resource`: Take a filename and copy that file into the app's Contents/Resources directory. May be used multiple times.

