### PR TITLE
Add Windows support to app-copyright

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 * [contributors] Add code coverage support via Coveralls (#257)
 * Better docs around contributing to the project (#258)
 
+### Deprecated
+
+* [win32] `version-string.LegalCopyright` is deprecated in favor of `app-copyright` (#268)
+
 ### Fixed
 
 * [darwin] Ensure `CFBundleVersion` and `CFBundleShortVersionString` are strings (#250)

--- a/readme.md
+++ b/readme.md
@@ -160,7 +160,7 @@ packager(opts, function done (err, appPath) { })
 
 `app-copyright` - *String*
 
-  The human-readable copyright line to use in the app plist, will be displayed in the application About box (OS X only).
+  The human-readable copyright line for the app. Maps to the `LegalCopyright` metadata property on Windows, and `NSHumanReadableCopyright` on OS X.
 
 `app-version` - *String*
 
@@ -246,7 +246,7 @@ If the file extension is omitted, it is auto-completed to the correct extension 
 
   Object hash of application metadata to embed into the executable (Windows only):
   - `CompanyName`
-  - `LegalCopyright`
+  - `LegalCopyright` (**deprecated** and will be removed in a future major version, pleas use the top-level `app-copyright` parameter instead)
   - `FileDescription`
   - `OriginalFilename`
   - `FileVersion` (**deprecated** and will be removed in a future major version, please use the top-level `build-version` parameter instead)

--- a/test/win32.js
+++ b/test/win32.js
@@ -91,6 +91,27 @@ function setAppAndProductVersionTest (appVersion, productVersion) {
   return generateVersionStringTest('ProductVersion', opts, appVersion, 'Product version should match app version')
 }
 
+function setLegalCopyrightTest (legalCopyright) {
+  var opts = {
+    'version-string': {
+      LegalCopyright: legalCopyright
+    }
+  }
+
+  return generateVersionStringTest('LegalCopyright', opts, legalCopyright, 'Legal copyright should match the value in version-string')
+}
+
+function setCopyrightOverrideTest (legalCopyright, appCopyright) {
+  var opts = {
+    'app-copyright': appCopyright,
+    'version-string': {
+      LegalCopyright: legalCopyright
+    }
+  }
+
+  return generateVersionStringTest('LegalCopyright', opts, appCopyright, 'Legal copyright should match app copyright')
+}
+
 util.setup()
 test('win32 file version test', setFileVersionTest('1.2.3.4'))
 util.teardown()
@@ -105,4 +126,12 @@ util.teardown()
 
 util.setup()
 test('win32 app version overrides product version test', setAppAndProductVersionTest('5.4.3.2', '4.3.2.1'))
+util.teardown()
+
+util.setup()
+test('win32 legal copyright test', setLegalCopyrightTest('Copyright Foo'))
+util.teardown()
+
+util.setup()
+test('win32 app copyright overrides LegalCopyright test', setCopyrightOverrideTest('Copyright Foo', 'Copyright Bar'))
 util.teardown()

--- a/usage.txt
+++ b/usage.txt
@@ -13,7 +13,7 @@ all                equivalent to --platform=all --arch=all
 app-bundle-id      bundle identifier to use in the app plist (darwin/mas platform only)
 app-category-type  the application category type (darwin/mas platform only)
                    For example, `app-category-type=public.app-category.developer-tools` will set the application category to 'Developer Tools'.
-app-copyright      human-readable copyright line to use in the app plist (darwin/mas platform only)
+app-copyright      human-readable copyright line for the app
 app-version        release version to set for the app
 asar               packages the source code within your app into an archive
 asar-unpack        unpacks the files to app.asar.unpacked directory whose filenames regex .match this string
@@ -38,7 +38,7 @@ version-string     should contain a hash of the application metadata to be embed
                    e.g. --version-string.CompanyName="Company Inc." --version-string.ProductName="Product"
                    Keys supported:
                    - CompanyName
-                   - LegalCopyright
+                   - LegalCopyright (deprecated, use --app-copyright instead)
                    - FileDescription
                    - OriginalFilename
                    - FileVersion (deprecated, use --build-version instead)

--- a/win32.js
+++ b/win32.js
@@ -34,6 +34,10 @@ module.exports = {
               } else if (opts['version-string'].ProductVersion) {
                 rcOpts['product-version'] = opts['version-string'].ProductVersion
               }
+
+              if (opts['app-copyright']) {
+                rcOpts['version-string'].LegalCopyright = opts['app-copyright']
+              }
             }
 
             // Icon might be omitted or only exist in one OS's format, so skip it if normalizeExt reports an error


### PR DESCRIPTION
Deprecate `version-string.LegalCopyright`.

Fixes #265.