### PR TITLE
Add option for child entitlements

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -163,7 +163,8 @@ module.exports = {
             // as boolean value true. Then fallback to null for auto discovery,
             // otherwise provided signing certificate.
             identity: opts.sign === true ? null : opts.sign,
-            entitlements: opts['sign-entitlements']
+            entitlements: opts['sign-entitlements'],
+            'entitlements-inherit': opts['sign-entitlements-inherit']
           }, function (err) {
             if (err) {
               console.warn('Code sign failed; please retry manually.')

--- a/readme.md
+++ b/readme.md
@@ -240,7 +240,11 @@ If the file extension is omitted, it is auto-completed to the correct extension 
 
 `sign-entitlements` - *String*
 
-  The path to entitlements used in signing. (Currently limited to Mac App Store distribution.)
+  The path to the 'parent' entitlements used in signing.
+
+ `sign-entitlements-inherit` - *String*
+
+  The path to the 'child' entitlements. See [electron-osx-sign](https://www.npmjs.com/package/electron-osx-sign#opts) for more details.
 
 `strict-ssl` - *Boolean*
 

--- a/usage.txt
+++ b/usage.txt
@@ -30,7 +30,9 @@ out                the dir to put the app into at the end. defaults to current w
 overwrite          if output directory for a platform already exists, replaces it rather than skipping it
 prune              runs `npm prune --production` on the app
 sign               should contain the identity to be used when running `codesign` (only for building for the darwin/mas platform, on OS X)
-sign-entitlements  the path to entitlements used in signing (mas platform only)
+sign-entitlements  the path to entitlements used in signing
+sign-entitlements-inherit
+                   the path to the 'child' entitlements
 strict-ssl         whether SSL certificates are required to be valid when downloading Electron.
                    It defaults to true, use --strict-ssl=false to disable checks.
 tmpdir             temp directory. Defaults to system temp directory, use --tmpdir=false to disable use of a temporary directory.


### PR DESCRIPTION
Allows the `entitlements-inherit` option of `electron-osx-sign` to be passed.

Related to #271