### PR TITLE
Consolidate OSX signing params

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
   files (#253)
 * Split out the code to sign OS X apps into a separate Node module,
   [electron-osx-sign](https://github.com/electron-userland/electron-osx-sign) (#223)
+* [darwin/mas] **BREAKING**: The `sign` parameter is now `osx-sign` (for better cross-platform
+  compatibility) and optionally takes several of the same sub-parameters as
+  electron-osx-sign (#286)
 
 ### Deprecated
 

--- a/cli.js
+++ b/cli.js
@@ -27,6 +27,11 @@ if (args.tmpdir === 'false') {
   args.tmpdir = false
 }
 
+// (in this case, `Object` or `true`)
+if (args['osx-sign'] === 'true') {
+  args['osx-sign'] = true
+}
+
 packager(args, function done (err, appPaths) {
   if (err) {
     if (err.message) console.error(err.message)

--- a/mac.js
+++ b/mac.js
@@ -189,21 +189,17 @@ module.exports = {
           signOpts.platform = opts.platform
           signOpts.app = finalAppPath
 
-          // Take argument sign as signing identity:
-          // Provided in command line --sign, opts.sign will be recognized
-          // as boolean value true. Then fallback to null for auto discovery,
-          // otherwise provided signing certificate.
+          // Take argument osx-sign as signing identity:
+          // if opts['osx-sign'] is true (bool), fallback to identity=null for
+          // autodiscovery. Otherwise, provide signing certificate info.
           if (signOpts.identity === true) {
             signOpts.identity = null
           }
 
-          // console.log('signOpts', signOpts, signOpts.__proto__, process.cwd())
-
           sign(signOpts, function (err) {
             if (err) {
+              // Although not signed successfully, the application is packed.
               console.warn('Code sign failed; please retry manually.', err)
-            // Though not signed successfully, the application is packed.
-            // It might have to be signed for another time manually.
             }
             cb()
           })

--- a/mac.js
+++ b/mac.js
@@ -34,7 +34,7 @@ function filterCFBundleIdentifier (identifier) {
 }
 
 function signOptsWarning (name) {
-  console.warn(`WARNING: osx-sign.${name} will be inferred from main options`)
+  console.warn('WARNING: osx-sign.' + name + ' will be inferred from main options')
 }
 
 module.exports = {

--- a/mac.js
+++ b/mac.js
@@ -37,9 +37,23 @@ function signOptsWarning (name) {
   console.warn('WARNING: osx-sign.' + name + ' will be inferred from main options')
 }
 
+function copyObject (target, source) {
+  if (typeof Object.assign === 'function') {
+    return Object.assign(target, source)
+  } else {
+    // Necessary for Node 0.12
+    for (var key in source) {
+      if (source.hasOwnProperty(key)) {
+        target[key] = source[key]
+      }
+    }
+    return target
+  }
+}
+
 function createSignOpts (properties, platform, app) {
   // use default sign opts if osx-sign is true, otherwise clone osx-sign object
-  var signOpts = properties === true ? {identity: null} : Object.assign({}, properties)
+  var signOpts = properties === true ? {identity: null} : copyObject({}, properties)
 
   // osx-sign options are handed off to sign module, but
   // with a few additions from main options

--- a/readme.md
+++ b/readme.md
@@ -258,25 +258,20 @@ If the file extension is omitted, it is auto-completed to the correct extension 
 
   The bundle identifier to use in the application helper's plist.
 
-`sign` - *String*
+`osx-sign` - *Object* or *true*
 
-  The identity used when signing the package via `codesign`. (Only for when XCode is present on the host platform.)
-
-`sign-entitlements` - *String*
-
-  The path to the 'parent' entitlements used in signing. (Only for when XCode is present on the host platform.)
-
-`sign-entitlements-inherit` - *String*
-
-  The path to the 'child' entitlements. See [electron-osx-sign](https://www.npmjs.com/package/electron-osx-sign#opts) for more details. (Only for when XCode is present on the host platform.)
+  If present, signs OS X target apps when the host platform is OS X and XCode is installed. When the value is `true`, pass default configuration to the signing module. The configuration values listed below can be customized when the value is an `Object`. See [electron-osx-sign](https://www.npmjs.com/package/electron-osx-sign#opts) for more detailed option descriptions and the defaults.
+  - `identity` - *String*: The identity used when signing the package via `codesign`.
+  - `entitlements` - *String*: The path to the 'parent' entitlements.
+  - `entitlements-inherit` - *String*: The path to the 'child' entitlements.
 
 ***Windows targets only***
 
 `version-string` - *Object*
 
-  Object hash of application metadata to embed into the executable:
+  Object (also known as a "hash") of application metadata to embed into the executable:
   - `CompanyName`
-  - `LegalCopyright` (**deprecated** and will be removed in a future major version, pleas use the top-level `app-copyright` parameter instead)
+  - `LegalCopyright` (**deprecated** and will be removed in a future major version, please use the top-level `app-copyright` parameter instead)
   - `FileDescription`
   - `OriginalFilename`
   - `FileVersion` (**deprecated** and will be removed in a future major version, please use the top-level `build-version` parameter instead)

--- a/test/mac.js
+++ b/test/mac.js
@@ -424,7 +424,7 @@ module.exports = function (baseOpts) {
     t.timeoutAfter(config.timeout)
 
     var opts = Object.create(baseOpts)
-    opts.sign = true // Ad-hoc
+    opts['osx-sign'] = true // Ad-hoc
 
     var appPath
 

--- a/test/mac.js
+++ b/test/mac.js
@@ -9,7 +9,7 @@ var waterfall = require('run-waterfall')
 var config = require('./config.json')
 var util = require('./util')
 var plist = require('plist')
-var filterCFBundleIdentifier = require('../mac').filterCFBundleIdentifier
+var mac = require('../mac')
 
 function createIconTest (baseOpts, icon, iconPath) {
   return function (t) {
@@ -219,7 +219,7 @@ function createAppBundleTest (baseOpts, appBundleId) {
       opts['app-bundle-id'] = appBundleId
     }
     var defaultBundleName = 'com.electron.' + opts.name.toLowerCase()
-    var appBundleIdentifier = filterCFBundleIdentifier(opts['app-bundle-id'] || defaultBundleName)
+    var appBundleIdentifier = mac.filterCFBundleIdentifier(opts['app-bundle-id'] || defaultBundleName)
 
     waterfall([
       function (cb) {
@@ -260,8 +260,8 @@ function createAppHelpersBundleTest (baseOpts, helperBundleId, appBundleId) {
       opts['app-bundle-id'] = appBundleId
     }
     var defaultBundleName = 'com.electron.' + opts.name.toLowerCase()
-    var appBundleIdentifier = filterCFBundleIdentifier(opts['app-bundle-id'] || defaultBundleName)
-    var helperBundleIdentifier = filterCFBundleIdentifier(opts['helper-bundle-id'] || appBundleIdentifier + '.helper')
+    var appBundleIdentifier = mac.filterCFBundleIdentifier(opts['app-bundle-id'] || defaultBundleName)
+    var helperBundleIdentifier = mac.filterCFBundleIdentifier(opts['helper-bundle-id'] || appBundleIdentifier + '.helper')
 
     waterfall([
       function (cb) {
@@ -417,6 +417,51 @@ module.exports = function (baseOpts) {
 
   util.setup()
   test('extra-resource test: two arg', createExtraResource2Test(baseOpts))
+  util.teardown()
+
+  util.setup()
+  test('osx-sign argument test: default args', function (t) {
+    var args = true
+    var sign_opts = mac.createSignOpts(args, 'darwin', 'out')
+    t.same(sign_opts, {identity: null, app: 'out', platform: 'darwin'})
+    t.end()
+  })
+  util.teardown()
+
+  util.setup()
+  test('osx-sign argument test: identity=true sets autodiscovery mode', function (t) {
+    var args = {identity: true}
+    var sign_opts = mac.createSignOpts(args, 'darwin', 'out')
+    t.same(sign_opts, {identity: null, app: 'out', platform: 'darwin'})
+    t.end()
+  })
+  util.teardown()
+
+  util.setup()
+  test('osx-sign argument test: entitlements passed to electron-osx-sign', function (t) {
+    var args = {entitlements: 'path-to-entitlements'}
+    var sign_opts = mac.createSignOpts(args, 'darwin', 'out')
+    t.same(sign_opts, {app: 'out', platform: 'darwin', entitlements: args.entitlements})
+    t.end()
+  })
+  util.teardown()
+
+  util.setup()
+  test('osx-sign argument test: app not overwritten', function (t) {
+    var args = {app: 'some-other-path'}
+    var sign_opts = mac.createSignOpts(args, 'darwin', 'out')
+    t.same(sign_opts, {app: 'out', platform: 'darwin'})
+    t.end()
+  })
+  util.teardown()
+
+  util.setup()
+  test('osx-sign argument test: platform not overwritten', function (t) {
+    var args = {platform: 'mas'}
+    var sign_opts = mac.createSignOpts(args, 'darwin', 'out')
+    t.same(sign_opts, {app: 'out', platform: 'darwin'})
+    t.end()
+  })
   util.teardown()
 
   util.setup()

--- a/usage.txt
+++ b/usage.txt
@@ -41,17 +41,21 @@ app-category-type  the application category type
 extend-info        a plist file to append to the app plist
 extra-resource     a file to copy into the app's Contents/Resources
 helper-bundle-id   bundle identifier to use in the app helper plist
-sign               should contain the identity to be used when running `codesign` (OS X host platform only)
-sign-entitlements  the path to entitlements used in signing (OS X host platform only)
-sign-entitlements-inherit
-                   the path to the 'child' entitlements (OS X host platform only)
+osx-sign           (OSX host platform only) Whether to sign the OSX app packages. You can either
+                   pass --osx-sign to enable with the default configuration, or use dot notation
+                   to configure a list of sub-properties, e.g. --osx-sign.identity="My Name"
+
+                   Properties supported:
+                   - identity: should contain the identity to be used when running `codesign`
+                   - entitlements: the path to entitlements used in signing
+                   - entitlements-inherit: the path to the 'child' entitlements
 
 * win32 target platform only *
 
-version-string     should contain a hash of the application metadata to be embedded into the executable.
-                   These can be specified on the command line via dot notation,
+version-string     a list of sub-properties used to set the application metadata embedded into the executable.
+                   They are specified via dot notation,
                    e.g. --version-string.CompanyName="Company Inc." --version-string.ProductName="Product"
-                   Keys supported:
+                   Properties supported:
                    - CompanyName
                    - LegalCopyright (deprecated, use --app-copyright instead)
                    - FileDescription

--- a/usage.txt
+++ b/usage.txt
@@ -42,7 +42,7 @@ extend-info        a plist file to append to the app plist
 extra-resource     a file to copy into the app's Contents/Resources
 helper-bundle-id   bundle identifier to use in the app helper plist
 osx-sign           (OSX host platform only) Whether to sign the OSX app packages. You can either
-                   pass --osx-sign to enable with the default configuration, or use dot notation
+                   pass --osx-sign by itself to use the default configuration, or use dot notation
                    to configure a list of sub-properties, e.g. --osx-sign.identity="My Name"
 
                    Properties supported:


### PR DESCRIPTION
Per discussion in #285, I feel that there are too many OS X signing options, and that it would be better to group them together. This has the added benefit of leaving in room for a potential future Windows signing module to be integrated (#32).

CC: @sethlu