### PR TITLE
Bump electron-download to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
     "asar": "^0.8.2",
-    "electron-download": "^1.0.0",
+    "electron-download": "^2.0.0",
     "electron-osx-sign": "^0.3.0",
     "extract-zip": "^1.0.3",
     "fs-extra": "^0.26.5",


### PR DESCRIPTION
Does this work? Also, want me not to bump electron-packager to 5.2.2?