### PR TITLE
Delete default_app.asar during packaging

### DIFF
--- a/common.js
+++ b/common.js
@@ -111,7 +111,11 @@ module.exports = {
         fs.copy(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: true}, cb)
       },
       function (cb) {
+        // Support removing old default_app folder that is now an asar archive
         rimraf(path.join(resourcesPath, 'default_app'), cb)
+      },
+      function (cb) {
+        rimraf(path.join(resourcesPath, 'default_app.asar'), cb)
       }
     ]
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -72,7 +72,12 @@ function createDefaultsTest (opts) {
         t.true(equal,
           'File under subdirectory of packaged app directory should match source file and not be ignored by default')
         fs.exists(path.join(resourcesPath, 'default_app'), function (exists) {
-          t.false(exists, 'The output directory should not contain the Electron default app')
+          t.false(exists, 'The output directory should not contain the Electron default app directory')
+          cb()
+        })
+      }, function (cb) {
+        fs.exists(path.join(resourcesPath, 'default_app.asar'), function (exists) {
+          t.false(exists, 'The output directory should not contain the Electron default app asar file')
           cb()
         })
       }


### PR DESCRIPTION
In the next Electron release (0.37.4), the `default_app/` folder will now be a `default_app.asar` file.

This pull request adds support for deleting `default_app.asar` during packaging.

https://github.com/atom/electron/pull/4956