### PR TITLE
Fix for issue 300: --icon option does not work under Electron 0.37.4

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -165,7 +165,7 @@ module.exports = {
               // Ignore error if icon doesn't exist, in case it's only available for other OS
               cb(null)
             } else {
-              ncp(icon, path.join(contentsPath, 'Resources', 'atom.icns'), cb)
+              ncp(icon, path.join(contentsPath, 'Resources', appPlist.CFBundleIconFile), cb)
             }
           })
         })

--- a/test/fixtures/el-0374/index.html
+++ b/test/fixtures/el-0374/index.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+	<body>Hello, world!</body>
+</html>

--- a/test/fixtures/el-0374/main.js
+++ b/test/fixtures/el-0374/main.js
@@ -1,0 +1,22 @@
+var app = require('app')
+var BrowserWindow = require('browser-window')
+var mainWindow
+
+app.on('window-all-closed', function () {
+  app.quit()
+})
+
+app.on('ready', function () {
+  mainWindow = new BrowserWindow({
+    center: true,
+    title: 'Basic Test',
+    width: 800,
+    height: 600
+  })
+
+  mainWindow.loadUrl('file://' + require('path').resolve(__dirname, 'index.html'))
+
+  mainWindow.on('closed', function () {
+    mainWindow = null
+  })
+})

--- a/test/fixtures/el-0374/package.json
+++ b/test/fixtures/el-0374/package.json
@@ -1,0 +1,12 @@
+{
+  "main": "main.js",
+  "productName": "MainJS",
+  "dependencies": {
+    "run-series": "^1.1.1"
+  },
+  "devDependencies": {
+    "ncp": "^2.0.0",
+    "run-waterfall": "^1.1.1",
+    "electron-prebuilt": "0.37.4"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -6,14 +6,21 @@ var series = require('run-series')
 var config = require('./config.json')
 var util = require('./util')
 
-// Download all Electron distributions before running tests to avoid timing out due to network speed
+// Download all Electron distributions before running tests to avoid timing out due to network speed.
+// Most tests run with the config.json version, but we have a special test (in mac.js) for 0.37.4.
 series([
   function (cb) {
     console.log('Calling electron-download before running tests...')
     util.downloadAll(config.version, cb)
   }, function (cb) {
+    console.log('Calling electron-download 0.37.4 before running tests...')
+    util.downloadAll('0.37.4', cb)
+  }, function (cb) {
     console.log('Running npm install in fixtures/basic...')
     exec('npm install', {cwd: path.join(__dirname, 'fixtures', 'basic')}, cb)
+  }, function (cb) {
+    console.log('Running npm install in fixtures/el-0374...')
+    exec('npm install', {cwd: path.join(__dirname, 'fixtures', 'el-0374')}, cb)
   }
 ], function () {
   console.log('Running tests...')


### PR DESCRIPTION
https://github.com/electron-userland/electron-packager/issues/300

This is an easy fix. It writes the icon to the filename defined in CFBundleIconFile, so it will work in Electron 0.37.4 as well as earlier versions.

Since the test/config.json specifies "0.35.6", there's no way to test this fix directly. Is that okay, or should we figure out how to test both configurations? (If so, how?)
