### PR TITLE
Appveyor CI support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "buffer-equal": "^1.0.0",
     "coveralls": "^2.11.6",
+    "is-admin": "^1.0.2",
     "nyc": "^6.0.0",
     "rcinfo": "^0.1.3",
     "rimraf": "^2.3.2",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,8 @@
 
 Package your [Electron](http://electron.atom.io) app into OS-specific bundles (`.app`, `.exe`, etc.) via JavaScript or the command line.
 
-[![Build Status](https://travis-ci.org/electron-userland/electron-packager.svg?branch=master)](https://travis-ci.org/electron-userland/electron-packager)
+[![Travis CI Build Status](https://travis-ci.org/electron-userland/electron-packager.svg?branch=master)](https://travis-ci.org/electron-userland/electron-packager)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/m51mlf6ntd138555?svg=true)](https://ci.appveyor.com/project/electron-userland/electron-packager)
 [![Coverage Status](https://coveralls.io/repos/github/electron-userland/electron-packager/badge.svg?branch=master)](https://coveralls.io/github/electron-userland/electron-packager?branch=master)
 
 ## About

--- a/test/basic.js
+++ b/test/basic.js
@@ -407,7 +407,10 @@ function createIgnoreOutDirTest (opts, distPath) {
       },
       function (cb) {
         // create file to ensure that directory will be not ignored because empty
-        fs.open(path.join(outDir, 'ignoreMe'), 'w', cb)
+        fs.open(path.join(outDir, 'ignoreMe'), 'w', function (err, fd) {
+          if (err) return cb(err)
+          fs.close(fd, cb)
+        })
       },
       function (cb) {
         packager(opts, cb)
@@ -449,7 +452,10 @@ function createIgnoreImplicitOutDirTest (opts) {
       },
       function (cb) {
         // create file to ensure that directory will be not ignored because empty
-        fs.open(path.join(previousPackedResultDir, testFilename), 'w', cb)
+        fs.open(path.join(previousPackedResultDir, testFilename), 'w', function (err, fd) {
+          if (err) return cb(err)
+          fs.close(fd, cb)
+        })
       },
       function (cb) {
         packager(opts, cb)

--- a/test/ci/appveyor.yml
+++ b/test/ci/appveyor.yml
@@ -1,0 +1,23 @@
+platform:
+- x86
+- x64
+environment:
+  matrix:
+  - nodejs_version: "4"
+  - nodejs_version: "5"
+cache:
+- '%APPDATA%\npm-cache'
+- '%USERPROFILE%\.electron'
+
+install:
+- ps: Install-Product node $env:nodejs_version $env:platform
+- npm install -g npm@3
+- set PATH=%APPDATA%\npm;%PATH%
+- npm install
+
+test_script:
+- node --version
+- npm --version
+- npm test
+
+build: off


### PR DESCRIPTION
Fixes part of #322.

This adds a devDependency (`is-admin`) because a test is dependent on whether a) it runs on Windows, and b) the test is running with elevated privileges, i.e., it can create symlinks.

I'm not sure if uploading code coverage to Coveralls is useful with Appveyor, just because it creates separate builds for each build in the matrix (and it doesn't execute as much code as Travis, because it's running on Windows).

@develar electron-builder's Appveyor tests run under the electron-userland org. Can I get access? (To the Appveyor org, not electron-builder.)

## TODO
* [x] Move Appveyor tests under the correct org
* [x] Add badge to README
* [x] Squash commits