### PR TITLE
Remove deprecated version-string subproperties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,12 @@
 * `cache` is deprecated in favor of `download.cache` (#320)
 * `strict-ssl` is deprecated in favor of `download.strictSSL` (#320)
 
+### Removed
+
+* [win32] `version-string.FileVersion` and `version-string.ProductVersion` are replaced by
+  favor of `app-version` and `build-version`, respectively (#327)
+* [win32] `version-string.LegalCopyright` is replaced by `app-copyright` (#327)
+
 ## [6.0.2] - 2016-04-09
 
 ### Changed

--- a/docs/api.md
+++ b/docs/api.md
@@ -222,11 +222,8 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 
 Object (also known as a "hash") of application metadata to embed into the executable:
 - `CompanyName`
-- `LegalCopyright` (**deprecated** and will be removed in a future major version, please use the top-level [`app-copyright`](#app-copyright) parameter instead)
 - `FileDescription`
 - `OriginalFilename`
-- `FileVersion` (**deprecated** and will be removed in a future major version, please use the top-level [`build-version`](#build-version) parameter instead)
-- `ProductVersion` (**deprecated** and will be removed in a future major version, please use the top-level [`app-version`](#app-version) parameter instead)
 - `ProductName`
 - `InternalName`
 

--- a/test/win32.js
+++ b/test/win32.js
@@ -15,7 +15,7 @@ var baseOpts = {
   platform: 'win32'
 }
 
-function generateVersionStringTest (metadata_property, extra_opts, expected_value, assertion_msg) {
+function generateVersionStringTest (metadata_properties, extra_opts, expected_values, assertion_msgs) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
@@ -34,7 +34,14 @@ function generateVersionStringTest (metadata_property, extra_opts, expected_valu
       }, function (cb) {
         rcinfo(appExePath, cb)
       }, function (info, cb) {
-        t.equal(info[metadata_property], expected_value, assertion_msg)
+        metadata_properties = [].concat(metadata_properties)
+        expected_values = [].concat(expected_values)
+        assertion_msgs = [].concat(assertion_msgs)
+        metadata_properties.forEach(function (property, i) {
+          var value = expected_values[i]
+          var msg = assertion_msgs[i]
+          t.equal(info[property], value, msg)
+        })
         cb()
       }
     ], function (err) {
@@ -43,89 +50,57 @@ function generateVersionStringTest (metadata_property, extra_opts, expected_valu
   }
 }
 
-function setFileVersionTest (fileVersion) {
+function setFileVersionTest (buildVersion) {
   var opts = {
-    'version-string': {
-      FileVersion: fileVersion
-    }
-  }
-
-  return generateVersionStringTest('FileVersion', opts, fileVersion, 'File version should match the value in version-string')
-}
-
-function setBuildAndFileVersionTest (buildVersion, fileVersion) {
-  var opts = {
-    'build-version': buildVersion,
-    'version-string': {
-      FileVersion: fileVersion
-    }
+    'build-version': buildVersion
   }
 
   return generateVersionStringTest('FileVersion', opts, buildVersion, 'File version should match build version')
 }
 
-function setProductVersionTest (productVersion) {
+function setProductVersionTest (appVersion) {
   var opts = {
-    'version-string': {
-      ProductVersion: productVersion
-    }
-  }
-
-  return generateVersionStringTest('ProductVersion', opts, productVersion, 'Product version should match the value in version-string')
-}
-
-function setAppAndProductVersionTest (appVersion, productVersion) {
-  var opts = {
-    'app-version': appVersion,
-    'version-string': {
-      ProductVersion: productVersion
-    }
+    'app-version': appVersion
   }
 
   return generateVersionStringTest('ProductVersion', opts, appVersion, 'Product version should match app version')
 }
 
-function setLegalCopyrightTest (legalCopyright) {
+function setCopyrightTest (appCopyright) {
   var opts = {
-    'version-string': {
-      LegalCopyright: legalCopyright
-    }
-  }
-
-  return generateVersionStringTest('LegalCopyright', opts, legalCopyright, 'Legal copyright should match the value in version-string')
-}
-
-function setCopyrightOverrideTest (legalCopyright, appCopyright) {
-  var opts = {
-    'app-copyright': appCopyright,
-    'version-string': {
-      LegalCopyright: legalCopyright
-    }
+    'app-copyright': appCopyright
   }
 
   return generateVersionStringTest('LegalCopyright', opts, appCopyright, 'Legal copyright should match app copyright')
 }
 
+function setCopyrightAndCompanyNameTest (appCopyright, companyName) {
+  var opts = {
+    'app-copyright': appCopyright,
+    'version-string': {
+      CompanyName: companyName
+    }
+  }
+
+  return generateVersionStringTest(['LegalCopyright', 'CompanyName'],
+                                   opts,
+                                   [appCopyright, companyName],
+                                   ['Legal copyright should match app copyright',
+                                    'Company name should match version-string value'])
+}
+
 util.setup()
-test('win32 file version test', setFileVersionTest('1.2.3.4'))
+test('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
 util.teardown()
 
 util.setup()
-test('win32 build version overrides file version test', setBuildAndFileVersionTest('2.3.4.5', '1.2.3.4'))
+test('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
 util.teardown()
 
 util.setup()
-test('win32 product version test', setProductVersionTest('4.3.2.1'))
+test('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
 util.teardown()
 
 util.setup()
-test('win32 app version overrides product version test', setAppAndProductVersionTest('5.4.3.2', '4.3.2.1'))
-util.teardown()
-
-util.setup()
-test('win32 legal copyright test', setLegalCopyrightTest('Copyright Foo'))
-util.teardown()
-
-util.setup()
-test('win32 app copyright overrides LegalCopyright test', setCopyrightOverrideTest('Copyright Foo', 'Copyright Bar'))
+test('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
 util.teardown()

--- a/usage.txt
+++ b/usage.txt
@@ -66,10 +66,7 @@ version-string     a list of sub-properties used to set the application metadata
                    e.g. --version-string.CompanyName="Company Inc." --version-string.ProductName="Product"
                    Properties supported:
                    - CompanyName
-                   - LegalCopyright (deprecated, use --app-copyright instead)
                    - FileDescription
                    - OriginalFilename
-                   - FileVersion (deprecated, use --build-version instead)
-                   - ProductVersion (deprecated, use --app-version instead)
                    - ProductName
                    - InternalName

--- a/win32.js
+++ b/win32.js
@@ -15,30 +15,23 @@ module.exports = {
         }
       ]
 
-      if (opts.icon || opts['version-string']) {
+      var rcOpts = {'version-string': opts['version-string'] || {}}
+
+      if (opts['build-version']) {
+        rcOpts['file-version'] = opts['build-version']
+      }
+
+      if (opts['app-version']) {
+        rcOpts['product-version'] = opts['app-version']
+      }
+
+      if (opts['app-copyright']) {
+        rcOpts['version-string'].LegalCopyright = opts['app-copyright']
+      }
+
+      if (opts.icon || opts['version-string'] || opts['app-copyright'] || opts['app-version'] || opts['build-version']) {
         operations.push(function (cb) {
           common.normalizeExt(opts.icon, '.ico', function (err, icon) {
-            var rcOpts = {}
-            if (opts['version-string']) {
-              rcOpts['version-string'] = opts['version-string']
-
-              if (opts['build-version']) {
-                rcOpts['file-version'] = opts['build-version']
-              } else if (opts['version-string'].FileVersion) {
-                rcOpts['file-version'] = opts['version-string'].FileVersion
-              }
-
-              if (opts['app-version']) {
-                rcOpts['product-version'] = opts['app-version']
-              } else if (opts['version-string'].ProductVersion) {
-                rcOpts['product-version'] = opts['version-string'].ProductVersion
-              }
-
-              if (opts['app-copyright']) {
-                rcOpts['version-string'].LegalCopyright = opts['app-copyright']
-              }
-            }
-
             // Icon might be omitted or only exist in one OS's format, so skip it if normalizeExt reports an error
             if (!err) {
               rcOpts.icon = icon


### PR DESCRIPTION
Also simplifies the implementation a bit (possibly depending on your point of view...), and makes the tests a little more comprehensive, making sure that passing strings to `version-string` actually works.