### PR TITLE
Add support for OSX on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+*.cer
+*.csr
+*.key
+*.pem
 node_modules
 test/work
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 sudo: required
 dist: trusty
+os:
+- osx
+osx_image: xcode7.3
 language: node_js
 node_js:
 - '4'
 - '5'
+# Does not yet work on OSX/GCE
+# See: https://github.com/travis-ci/travis-ci/issues/4011
 cache:
 - directories:
   - "$HOME/.npm"
   - "$HOME/.electron"
+  - /Library/Caches/Homebrew
 before_install: test/ci/before_install.sh
 after_success: npm run coveralls
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required
-dist: trusty
+sudo: false
 os:
+- linux
 - osx
 osx_image: xcode7.3
 language: node_js
@@ -10,10 +10,15 @@ node_js:
 # Does not yet work on OSX/GCE
 # See: https://github.com/travis-ci/travis-ci/issues/4011
 cache:
+- apt: true
 - directories:
   - "$HOME/.npm"
   - "$HOME/.electron"
   - /Library/Caches/Homebrew
+addons:
+  apt:
+    packages:
+    - wine
 before_install: test/ci/before_install.sh
 after_success: npm run coveralls
 env:

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -9,4 +9,27 @@ case "$TRAVIS_OS_NAME" in
     sudo apt-get update
     sudo apt-get install --no-install-recommends --yes wine1.6
     ;;
+  "osx")
+    # Install Wine
+    BREW_INSTALL="brew install --ignore-dependencies --force-bottle"
+    brew update
+    $BREW_INSTALL freetype
+    brew deps --skip-optional wine | grep -v freetype | xargs $BREW_INSTALL
+    $BREW_INSTALL wine
+    # Create CA
+    openssl req -newkey rsa:4096 -days 1 -x509 -nodes -subj \
+      "/C=CI/ST=Travis/L=Developer/O=Developer/CN=Developer CA" \
+      -out /tmp/root.cer -keyout /tmp/root.key
+    touch /tmp/certindex
+    sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+      /tmp/root.cer
+    # Create dev certificate
+    openssl req -newkey rsa:1024 -nodes -subj \
+      "/C=CI/ST=Travis/L=Developer/O=Developer/CN=Developer CodeCert" \
+      -out codesign.csr -keyout codesign.key
+    openssl ca -batch -config $(pwd)/test/ci/dev_ca.cnf -notext -create_serial \
+      -in codesign.csr -out codesign.cer
+    openssl pkcs12 -export -in codesign.cer -inkey codesign.key -out codesign.p12 -password pass:12345
+    security import codesign.p12 -k ~/Library/Keychains/login.keychain -P 12345 -T /usr/bin/codesign
+    ;;
 esac

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -2,13 +2,6 @@
 # -*- coding: utf-8 -*-
 
 case "$TRAVIS_OS_NAME" in
-  "linux")
-    sudo dpkg --add-architecture i386
-    # Chrome source does not work because they no longer support i386
-    sudo rm /etc/apt/sources.list.d/google-chrome.list*
-    sudo apt-get update
-    sudo apt-get install --no-install-recommends --yes wine1.6
-    ;;
   "osx")
     # Install Wine
     BREW_INSTALL="brew install --ignore-dependencies --force-bottle"

--- a/test/ci/dev_ca.cnf
+++ b/test/ci/dev_ca.cnf
@@ -1,0 +1,33 @@
+[ ca ]
+default_ca = devca
+
+[ crl_ext ]
+authorityKeyIdentifier=keyid:always
+
+[ devca ]
+new_certs_dir = /tmp
+unique_subject = no
+certificate = /tmp/root.cer
+database = /tmp/certindex
+private_key = /tmp/root.key
+serial = /tmp/serialfile
+default_days = 1
+default_md = sha1
+policy = devca_policy
+x509_extensions = devca_extensions
+
+[ devca_policy ]
+commonName = supplied
+stateOrProvinceName = supplied
+countryName = supplied
+emailAddress = optional
+organizationName = supplied
+organizationalUnitName = optional
+
+[ devca_extensions ]
+basicConstraints = CA:false
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = codeSigning
+crlDistributionPoints = URI:http://path.to.crl/devca.crl

--- a/test/config.json
+++ b/test/config.json
@@ -1,4 +1,5 @@
 {
   "timeout": 30000,
+  "macTimeout": 60000,
   "version": "0.35.6"
 }

--- a/test/mac.js
+++ b/test/mac.js
@@ -477,7 +477,7 @@ module.exports = function (baseOpts) {
     t.timeoutAfter(config.timeout)
 
     var opts = Object.create(baseOpts)
-    opts['osx-sign'] = true // Ad-hoc
+    opts['osx-sign'] = {identity: 'Developer CodeCert'}
 
     var appPath
 

--- a/test/win32.js
+++ b/test/win32.js
@@ -17,7 +17,7 @@ var baseOpts = {
 
 function generateVersionStringTest (metadata_properties, extra_opts, expected_values, assertion_msgs) {
   return function (t) {
-    t.timeoutAfter(config.timeout)
+    t.timeoutAfter(process.platform === 'darwin' ? config.macTimeout : config.timeout)
 
     var appExePath
     var opts = Object.assign({}, baseOpts, extra_opts)


### PR DESCRIPTION
Fixes part of #322.

@sethlu I've figured out how to get `codesign` working here, if you want I can adapt this method for `electron-osx-sign`.