### PR TITLE
CLI argument parsing code refactor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+
+## [7.0.1] - 2016-04-20
+
+### Fixed
+
+* Not specifying `strict-ssl` CLI parameter no longer triggers a deprecation warning (#335)
+
 ## [7.0.0] - 2016-04-17
 
 ### Added
@@ -121,6 +128,7 @@
 
 For versions prior to 5.2.0, please see `git log`.
 
+[7.0.1]: https://github.com/electron-userland/electron-packager/compare/v7.0.0...v7.0.1
 [7.0.0]: https://github.com/electron-userland/electron-packager/compare/v6.0.2...v7.0.0
 [6.0.2]: https://github.com/electron-userland/electron-packager/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/electron-userland/electron-packager/compare/v6.0.0...v6.0.1

--- a/cli.js
+++ b/cli.js
@@ -1,48 +1,15 @@
 #!/usr/bin/env node
+var common = require('./common')
 var fs = require('fs')
-var args = require('minimist')(process.argv.slice(2), {
-  boolean: [
-    'prune',
-    'asar',
-    'all',
-    'overwrite',
-    'strict-ssl',
-    'download.strictSSL'
-  ],
-  default: {
-    'strict-ssl': true,
-    'download.strictSSL': true
-  }
-})
 var packager = require('./')
 var path = require('path')
 var usage = fs.readFileSync(path.join(__dirname, 'usage.txt')).toString()
 
-args.dir = args._[0]
-args.name = args._[1]
-
-var protocolSchemes = [].concat(args.protocol || [])
-var protocolNames = [].concat(args['protocol-name'] || [])
-
-if (protocolSchemes && protocolNames && protocolNames.length === protocolSchemes.length) {
-  args.protocols = protocolSchemes.map(function (scheme, i) {
-    return {schemes: [scheme], name: protocolNames[i]}
-  })
-}
+var args = common.parseCLIArgs(process.argv.slice(2))
 
 if (!args.dir || (!args.all && (!args.platform || !args.arch))) {
   console.error(usage)
   process.exit(1)
-}
-
-// minimist doesn't support multiple types for a single argument (in this case, `String` or `false`)
-if (args.tmpdir === 'false') {
-  args.tmpdir = false
-}
-
-// (in this case, `Object` or `true`)
-if (args['osx-sign'] === 'true') {
-  args['osx-sign'] = true
 }
 
 packager(args, function done (err, appPaths) {

--- a/common.js
+++ b/common.js
@@ -18,8 +18,10 @@ function parseCLIArgs (argv) {
       'overwrite',
       'download.strictSSL'
     ],
+    alias: {
+      'download.strictSSL': 'strict-ssl'
+    },
     default: {
-      'strict-ssl': true,
       'download.strictSSL': true
     }
   })

--- a/common.js
+++ b/common.js
@@ -1,12 +1,53 @@
 var asar = require('asar')
 var child = require('child_process')
 var fs = require('fs-extra')
+var minimist = require('minimist')
 var os = require('os')
 var path = require('path')
 var series = require('run-series')
 
 var archs = ['ia32', 'x64']
 var platforms = ['darwin', 'linux', 'mas', 'win32']
+
+function parseCLIArgs (argv) {
+  var args = minimist(argv, {
+    boolean: [
+      'prune',
+      'asar',
+      'all',
+      'overwrite',
+      'download.strictSSL'
+    ],
+    default: {
+      'strict-ssl': true,
+      'download.strictSSL': true
+    }
+  })
+
+  args.dir = args._[0]
+  args.name = args._[1]
+
+  var protocolSchemes = [].concat(args.protocol || [])
+  var protocolNames = [].concat(args['protocol-name'] || [])
+
+  if (protocolSchemes && protocolNames && protocolNames.length === protocolSchemes.length) {
+    args.protocols = protocolSchemes.map(function (scheme, i) {
+      return {schemes: [scheme], name: protocolNames[i]}
+    })
+  }
+
+  // minimist doesn't support multiple types for a single argument (in this case, `String` or `false`)
+  if (args.tmpdir === 'false') {
+    args.tmpdir = false
+  }
+
+  // (in this case, `Object` or `true`)
+  if (args['osx-sign'] === 'true') {
+    args['osx-sign'] = true
+  }
+
+  return args
+}
 
 function asarApp (appPath, asarOptions, cb) {
   var src = path.join(appPath)
@@ -86,6 +127,8 @@ function userIgnoreFilter (opts) {
 module.exports = {
   archs: archs,
   platforms: platforms,
+
+  parseCLIArgs: parseCLIArgs,
 
   isPlatformMac: function isPlatformMac (platform) {
     return platform === 'darwin' || platform === 'mas'

--- a/test/basic.js
+++ b/test/basic.js
@@ -515,6 +515,30 @@ test('download argument test: download.{arch,platform,version} does not overwrit
   t.end()
 })
 
+test('CLI argument test: --strict-ssl default', function (t) {
+  var args = common.parseCLIArgs([])
+  t.true(args['strict-ssl'], 'default for --strict-ssl is true')
+  t.end()
+})
+
+test('CLI argument test: --download.strictSSL default', function (t) {
+  var args = common.parseCLIArgs([])
+  t.true(args.download.strictSSL, 'default for --download.strictSSL is true')
+  t.end()
+})
+
+test('CLI argument test: --tmpdir=false', function (t) {
+  var args = common.parseCLIArgs(['--tmpdir=false'])
+  t.equal(args.tmpdir, false)
+  t.end()
+})
+
+test('CLI argument test: --osx-sign=true', function (t) {
+  var args = common.parseCLIArgs(['--osx-sign=true'])
+  t.equal(args['osx-sign'], true)
+  t.end()
+})
+
 util.testSinglePlatform('infer test', createInferTest)
 util.testSinglePlatform('defaults test', createDefaultsTest)
 util.testSinglePlatform('default_app.asar removal test', createDefaultAppAsarTest)


### PR DESCRIPTION
Moves CLI argument parsing code to the common module. This allows the CLI argument parsing code to be unit tested (of which, tests for some corner cases have been added).

Also uses `alias` for the deprecated `--strict-ssl` flag. This should remove the consistent deprecation message. <sup>[[1]](https://github.com/electron-userland/electron-packager/pull/320#discussion_r60160184) [[2]](https://github.com/electron-userland/electron-packager/pull/320#commitcomment-17173369)</sup>

My intention is to release 7.0.1 once this is merged.

## TODO

* [x] add NEWS entry