### PR TITLE
Remove spaces from CFBundleExecutable key

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var asar = require('asar')
 var child = require('child_process')
 var fs = require('fs-extra')
@@ -5,6 +7,7 @@ var minimist = require('minimist')
 var os = require('os')
 var path = require('path')
 var series = require('run-series')
+const sanitize = require('sanitize-filename')
 
 var archs = ['ia32', 'x64']
 var platforms = ['darwin', 'linux', 'mas', 'win32']
@@ -254,5 +257,9 @@ module.exports = {
     fs.stat(filename, function (err) {
       cb(err, err ? null : filename)
     })
+  },
+
+  sanitizeExeFilename: function (name) {
+    return sanitize(name.replace(/\s+/g, '_'))
   }
 }

--- a/mac.js
+++ b/mac.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var common = require('./common')
 var fs = require('fs-extra')
 var path = require('path')
@@ -98,7 +100,7 @@ module.exports = {
       appPlist.CFBundleName = opts.name
       helperPlist.CFBundleDisplayName = opts.name + ' Helper'
       helperPlist.CFBundleIdentifier = helperBundleIdentifier
-      appPlist.CFBundleExecutable = opts.name
+      appPlist.CFBundleExecutable = common.sanitizeExeFilename(opts.name)
       helperPlist.CFBundleName = opts.name
       helperPlist.CFBundleExecutable = opts.name + ' Helper'
       helperEHPlist.CFBundleDisplayName = opts.name + ' Helper EH'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "electron-download": "^2.0.0",
     "electron-osx-sign": "^0.3.0",
     "extract-zip": "^1.0.3",
-    "fs-extra": "^0.26.5",
+    "fs-extra": "^0.28.0",
     "get-package-info": "0.0.2",
     "minimist": "^1.1.1",
     "plist": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "plist": "^1.1.0",
     "rcedit": "^0.5.0",
     "resolve": "^1.1.6",
-    "run-series": "^1.1.1"
+    "run-series": "^1.1.1",
+    "sanitize-filename": "^1.5.3"
   },
   "devDependencies": {
     "buffer-equal": "^1.0.0",

--- a/test/mac.js
+++ b/test/mac.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var config = require('./config.json')
 var exec = require('child_process').exec
 var fs = require('fs')
@@ -7,6 +9,7 @@ var path = require('path')
 var plist = require('plist')
 var test = require('tape')
 var util = require('./util')
+const common = require('../common')
 var waterfall = require('run-waterfall')
 
 function createIconTest (baseOpts, icon, iconPath) {
@@ -506,7 +509,9 @@ module.exports = function (baseOpts) {
   test('binary naming test', function (t) {
     t.timeoutAfter(config.timeout)
 
-    var opts = Object.create(baseOpts)
+    const opts = Object.assign({}, baseOpts)
+    // test space in name
+    opts.name = 'Test App'
     var binaryPath
 
     waterfall([
@@ -514,7 +519,7 @@ module.exports = function (baseOpts) {
         packager(opts, cb)
       }, function (paths, cb) {
         binaryPath = path.join(paths[0], opts.name + '.app', 'Contents', 'MacOS')
-        fs.stat(path.join(binaryPath, opts.name), cb)
+        fs.stat(path.join(binaryPath, common.sanitizeExeFilename(opts.name)), cb)
       }, function (stats, cb) {
         t.true(stats.isFile(), 'The binary should reflect opts.name')
         cb()

--- a/win32.js
+++ b/win32.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var common = require('./common')
 var fs = require('fs-extra')
 var path = require('path')
@@ -8,7 +10,7 @@ module.exports = {
     common.initializeApp(opts, templatePath, path.join('resources', 'app'), function buildWinApp (err, tempPath) {
       if (err) return callback(err)
 
-      var newExePath = path.join(tempPath, `${opts.name}.exe`)
+      const newExePath = path.join(tempPath, `${common.sanitizeExeFilename(opts.name)}.exe`)
       var operations = [
         function (cb) {
           fs.move(path.join(tempPath, 'electron.exe'), newExePath, cb)


### PR DESCRIPTION
Fixes #339.

and Squirrel.Windows bug "Windows shortcut doesn't work when `productName` contains a space" (https://github.com/electron-userland/electron-builder/issues/339)


Related issue: https://github.com/electron-userland/electron-builder/issues/288

Yes, this commit breaks electron-builder, but it will be fixed today in a separate commit (maybe some changes will be required on electron-packager side).