### PR TITLE
Escape dot in ".git" correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ module.exports = function packager (opts, cb) {
     }
 
     // Ignore this and related modules by default
-    var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\.git($|/)', '/node_modules/\\.bin($|/)']
+    var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\\.git($|/)', '/node_modules/\\.bin($|/)']
 
     if (typeof (opts.ignore) !== 'function') {
       if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]


### PR DESCRIPTION
Previously, folders name “agit” or “bgit" would get ignored.