### PR TITLE
Implemented an 'afterExtract' function hook  RE: #270

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -45,6 +45,18 @@ The non-`all` values correspond to the platform names used by [Electron releases
 
 #### All Platforms
 
+##### `afterExtract`
+
+*Array of Functions*
+
+An array of functions to be called after Electron has been extracted to a temporary directory.  Each function is called with five parameters:
+
+- `buildPath` (*String*): The path to the temporary folder where Electron has been extracted to
+- `electronVersion` (*String*): The version of electron you are packaging for
+- `platform` (*String*): The target platform you are packaging for
+- `arch` (*String*): The target architecture you are packaging for
+- `callback` (*Function*): Must be called once you have completed your actions
+
 ##### `all`
 
 *Boolean*

--- a/index.js
+++ b/index.js
@@ -128,6 +128,16 @@ function createSeries (opts, archs, platforms) {
             },
             function (cb) {
               extract(zipPath, {dir: buildDir}, cb)
+            },
+            function (cb) {
+              if (!opts.afterExtract || !Array.isArray(opts.afterExtract)) {
+                cb()
+              } else {
+                var newFunctions = opts.afterExtract.map(function (fn) {
+                  return fn.bind(this, buildDir, version, platform, arch)
+                })
+                series(newFunctions, cb)
+              }
             }
           ], function () {
             require(supportedPlatforms[platform]).createApp(comboOpts, buildDir, callback)

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,60 @@
+'use strict'
+
+var config = require('./config.json')
+var fs = require('fs')
+var packager = require('..')
+var path = require('path')
+var series = require('run-series')
+var test = require('tape')
+var util = require('./util')
+var waterfall = require('run-waterfall')
+
+function verifyPackageExistence (finalPaths, callback) {
+  series(finalPaths.map(function (finalPath) {
+    return function (cb) {
+      fs.stat(finalPath, cb)
+    }
+  }), function (err, statsResults) {
+    if (err) return callback(null, false)
+
+    callback(null, statsResults.every(function (stats) {
+      return stats.isDirectory()
+    }))
+  })
+}
+
+util.setup()
+test('platform=all test (one arch) (afterExtract hook)', function (t) {
+  t.timeoutAfter(config.timeout * 2) // 2 packages will be built during this test
+
+  var afterExtractCalled = false
+  var opts = {
+    name: 'basicTest',
+    dir: path.join(__dirname, 'fixtures', 'basic'),
+    version: config.version,
+    arch: 'ia32',
+    platform: 'all',
+    afterExtract: [function testAfterExtract (buildPath, electronVersion, platform, arch, callback) {
+      afterExtractCalled = true
+      t.equal(electronVersion, opts.version, 'afterExtract electronVersion should be the same as the options object')
+      t.equal(arch, opts.arch, 'afterExtract arch should be the same as the options object')
+      callback()
+    }]
+  }
+
+  waterfall([
+    function (cb) {
+      packager(opts, cb)
+    }, function (finalPaths, cb) {
+      t.equal(finalPaths.length, 2, 'packager call should resolve with expected number of paths')
+      t.true(afterExtractCalled, 'afterExtract methods should have been called')
+      verifyPackageExistence(finalPaths, cb)
+    }, function (exists, cb) {
+      t.true(exists, 'Packages should be generated for both 32-bit platforms')
+      cb()
+    }
+  ], function (err) {
+    t.end(err)
+  })
+})
+util.teardown()

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,7 @@ series([
 ], function () {
   console.log('Running tests...')
   require('./basic')
+  require('./hooks')
   require('./multitarget')
   require('./win32')
 


### PR DESCRIPTION
This PR adds an `afterExtract` option to the API.  This option should be an array of functions, each of which is called directly after `electron-packager` has finished extracting to the temporary directory.

Relevant issue: #270 