### PR TITLE
Remove hard dependency on electron-prebuilt

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function validateList (list, supported, name) {
 function getNameAndVersion (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
-  if (!opts.version) props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt', 'electron-version'])
+  if (!opts.version) props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt', 'config.electron-version'])
 
   // Name and version provided, no need to infer
   if (props.length === 0) return cb(null)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function validateList (list, supported, name) {
 function getNameAndVersion (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
-  if (!opts.version) props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt'])
+  if (!opts.version) props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt', 'electron-version'])
 
   // Name and version provided, no need to infer
   if (props.length === 0) return cb(null)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function validateList (list, supported, name) {
 function getNameAndVersion (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
-  if (!opts.version) props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt', 'config.electron-version'])
+  if (!opts.version) props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt'], 'config.electron-version')
 
   // Name and version provided, no need to infer
   if (props.length === 0) return cb(null)
@@ -50,6 +50,10 @@ function getNameAndVersion (opts, dir, cb) {
   getPackageInfo(props, dir, function (err, result) {
     if (err) return cb(err)
     if (result.values.productName) opts.name = result.values.productName
+    if (result.values['config.electron-version']) {
+      opts.version = result.values['config.electron-version']
+      return cb(null)
+    }
     if (result.values['dependencies.electron-prebuilt']) {
       resolve('electron-prebuilt', {
         basedir: path.dirname(result.source['dependencies.electron-prebuilt'].src)


### PR DESCRIPTION
This means packager will also use electron version specified in `electron-version` field in package.json

This is good because we don't have to depend on `electron-prebuilt`. `prebuilt` automatically downloads
electron for the current platform, but `packager` might only be building for a different platform, and will use
`electron-download` anyway, so we can avoid unnecessary download, and speed up `npm install` time.
