### PR TITLE
Added the ability to use .electronignore files to ignore on building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 test/work
 .DS_Store
 .nyc_output
+.idea/*

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [7.0.3] - 2016-05-25
+
+### Added
+
+* Add support to use `.electronignore` and `.electronignore_{platform}` files.
 
 ## [7.0.2] - 2016-05-18
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,19 @@ function getNameAndVersion (opts, dir, cb) {
   })
 }
 
+function getIgnoresFromFile (platform) {
+  var ignores = []
+  // check the global file ignores
+  if (fs.existsSync('./.electronignore')) {
+    ignores = fs.readFileSync('./.electronignore', 'utf8').split('\n')
+  }
+  // check the OS specific file ignores
+  if (fs.existsSync(`./.electronignore_${platform}`)) {
+    ignores = ignores.concat(fs.readFileSync(`./.electronignore_${platform}`, 'utf8').split('\n'))
+  }
+  return ignores
+}
+
 function createSeries (opts, archs, platforms) {
   var tempBase = path.join(opts.tmpdir || os.tmpdir(), 'electron-packager')
 
@@ -193,6 +206,8 @@ module.exports = function packager (opts, cb) {
     if (typeof (opts.ignore) !== 'function') {
       if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
       opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
+      // check for the .electronignore files.
+      opts.ignore = (opts.ignore) ? opts.ignore.concat(getIgnoresFromFile(opts.platform)) : defaultIgnores
     }
 
     series(createSeries(opts, archs, platforms), function (err, appPaths) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-packager",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Package and distribute your Electron app with OS-specific bundles (.app, .exe etc) via JS or CLI",
   "main": "index.js",
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,11 @@ If `appname` is omitted, this will use the name specified by "productName" or "n
 
 You should be able to launch the app on the platform you built for. If not, check your settings and try again.
 
+#### Ignoring files
+
 **Be careful** not to include `node_modules` you don't want into your final app. `electron-packager`, `electron-prebuilt` and `.git` will be ignored by default. You can use `--ignore` to ignore files and folders via a regular expression. For example, `--ignore=node_modules/package-to-ignore` or `--ignore="node_modules/(some-package[0-9]*|dev-dependency)"`.
+
+You can also ignore via `.electronignore` and `.electron_{platform}` files, similar to how you would create a `.gitignore` file. These files will automatically be processed and appended to the ignore rules sent as `--ignore`. In addition, the standard `.electronignore` file will be combined with the platform specific ignore file allowing more options for configuration.
 
 #### Example
 

--- a/test/fixtures/basic/.electronignore
+++ b/test/fixtures/basic/.electronignore
@@ -1,0 +1,1 @@
+ignorethis.txt


### PR DESCRIPTION
For our particular use case we had quite a few files we wanted to ignore and the ability to add these to a file that could be tracked within our repo was a more comfortable option rather than modifying the actual build scripts each time we needed to add something we wanted to ignore.
