### PR TITLE
temporary fix for node 6 stdio issue

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,6 +11,10 @@ var usage = fs.readFileSync(path.join(__dirname, 'usage.txt')).toString()
 var args = common.parseCLIArgs(process.argv.slice(2))
 
 if (!args.dir || (!args.all && (!args.platform || !args.arch))) {
+  // temporary fix for https://github.com/nodejs/node/issues/6456
+  if (process.stderr._handle && process.stderr._handle.setBlocking) {
+    process.stderr._handle.setBlocking(true)
+  }
   console.error(usage)
   process.exit(1)
 }


### PR DESCRIPTION
Because of https://github.com/nodejs/node/issues/6456, in node@6 you don't (yet) see all of the usage text because the process exits before all was written out. This is a temporary fix.