### PR TITLE
Upgrade electron-osx-sign to 0.4.1

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -195,6 +195,7 @@ class MacApp {
   enqueueAppSigningIfSpecified () {
     let osxSignOpt = this.opts['osx-sign']
     let platform = this.opts.platform
+    let version = this.opts.version
 
     if ((platform === 'all' || platform === 'mas') &&
         osxSignOpt === undefined) {
@@ -204,7 +205,7 @@ class MacApp {
 
     if (osxSignOpt) {
       this.operations.push((cb) => {
-        let signOpts = createSignOpts(osxSignOpt, platform, this.renamedAppPath)
+        let signOpts = createSignOpts(osxSignOpt, platform, this.renamedAppPath, version)
         debug(`Running electron-osx-sign with the options ${JSON.stringify(signOpts)}`)
         sign(signOpts, (err) => {
           if (err) {
@@ -232,15 +233,16 @@ function filterCFBundleIdentifier (identifier) {
   return identifier.replace(/ /g, '-').replace(/[^a-zA-Z0-9.-]/g, '')
 }
 
-function createSignOpts (properties, platform, app) {
+function createSignOpts (properties, platform, app, version) {
   // use default sign opts if osx-sign is true, otherwise clone osx-sign object
   let signOpts = properties === true ? {identity: null} : Object.assign({}, properties)
 
   // osx-sign options are handed off to sign module, but
   // with a few additions from the main options
-  // user may think they can pass platform or app, but they will be ignored
+  // user may think they can pass platform, app, or version, but they will be ignored
   common.subOptionWarning(signOpts, 'osx-sign', 'platform', platform)
   common.subOptionWarning(signOpts, 'osx-sign', 'app', app)
+  common.subOptionWarning(signOpts, 'osx-sign', 'version', version)
 
   if (signOpts.binaries) {
     console.warn('WARNING: osx-sign.binaries is not an allowed sub-option. Not passing to electron-osx-sign.')

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "asar": "^0.12.3",
     "debug": "^2.2.0",
     "electron-download": "^3.0.0",
-    "electron-osx-sign": "^0.3.0",
+    "electron-osx-sign": "^0.4.1",
     "extract-zip": "^1.0.3",
     "fs-extra": "^0.30.0",
     "get-package-info": "^1.0.0",

--- a/test/mac.js
+++ b/test/mac.js
@@ -552,43 +552,43 @@ module.exports = (baseOpts) => {
 
   test('osx-sign argument test: default args', function (t) {
     var args = true
-    var signOpts = mac.createSignOpts(args, 'darwin', 'out')
-    t.same(signOpts, {identity: null, app: 'out', platform: 'darwin'})
+    var signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
+    t.same(signOpts, {identity: null, app: 'out', platform: 'darwin', version: 'version'})
     t.end()
   })
 
   test('osx-sign argument test: identity=true sets autodiscovery mode', function (t) {
     var args = {identity: true}
-    var signOpts = mac.createSignOpts(args, 'darwin', 'out')
-    t.same(signOpts, {identity: null, app: 'out', platform: 'darwin'})
+    var signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
+    t.same(signOpts, {identity: null, app: 'out', platform: 'darwin', version: 'version'})
     t.end()
   })
 
   test('osx-sign argument test: entitlements passed to electron-osx-sign', function (t) {
     var args = {entitlements: 'path-to-entitlements'}
-    var signOpts = mac.createSignOpts(args, 'darwin', 'out')
-    t.same(signOpts, {app: 'out', platform: 'darwin', entitlements: args.entitlements})
+    var signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
+    t.same(signOpts, {app: 'out', platform: 'darwin', version: 'version', entitlements: args.entitlements})
     t.end()
   })
 
   test('osx-sign argument test: app not overwritten', function (t) {
     var args = {app: 'some-other-path'}
-    var signOpts = mac.createSignOpts(args, 'darwin', 'out')
-    t.same(signOpts, {app: 'out', platform: 'darwin'})
+    var signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
+    t.same(signOpts, {app: 'out', platform: 'darwin', version: 'version'})
     t.end()
   })
 
   test('osx-sign argument test: platform not overwritten', function (t) {
     var args = {platform: 'mas'}
-    var signOpts = mac.createSignOpts(args, 'darwin', 'out')
-    t.same(signOpts, {app: 'out', platform: 'darwin'})
+    var signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
+    t.same(signOpts, {app: 'out', platform: 'darwin', version: 'version'})
     t.end()
   })
 
   test('osx-sign argument test: binaries not set', (t) => {
     let args = {binaries: ['binary1', 'binary2']}
-    let signOpts = mac.createSignOpts(args, 'darwin', 'out')
-    t.same(signOpts, {app: 'out', platform: 'darwin'})
+    let signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
+    t.same(signOpts, {app: 'out', platform: 'darwin', version: 'version'})
     t.end()
   })
 


### PR DESCRIPTION
Hi @malept, I'm only posting this PR for now. Further tests may be required before eventually merging this I think. Hopefully a stable version of `electron-osx-sign` could be released later this week.
