### PR TITLE
Add option for dereferencing symlinks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+
+* Add `derefSymlinks` option (#410)
 
 ## [7.1.0] - 2016-06-22
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-* Add `derefSymlinks` option (#410)
+* `derefSymlinks` option (#410)
 
 ## [7.1.0] - 2016-06-22
 

--- a/common.js
+++ b/common.js
@@ -187,7 +187,11 @@ module.exports = {
         fs.move(templatePath, tempPath, {clobber: true}, cb)
       },
       function (cb) {
-        fs.copy(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: true}, cb)
+        var shouldDeref = opts.derefSymlinks
+        if (shouldDeref == null) {
+          shouldDeref = true
+        }
+        fs.copy(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: shouldDeref}, cb)
       },
       function (cb) {
         // Support removing old default_app folder that is now an asar archive

--- a/common.js
+++ b/common.js
@@ -23,7 +23,8 @@ function parseCLIArgs (argv) {
     ],
     default: {
       'strict-ssl': true,
-      'download.strictSSL': true
+      'download.strictSSL': true,
+      'deref-symlinks': true
     }
   })
 
@@ -187,10 +188,7 @@ module.exports = {
         fs.move(templatePath, tempPath, {clobber: true}, cb)
       },
       function (cb) {
-        var shouldDeref = opts.derefSymlinks
-        if (shouldDeref == null) {
-          shouldDeref = true
-        }
+        var shouldDeref = opts['deref-symlinks']
         fs.copy(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: shouldDeref}, cb)
       },
       function (cb) {

--- a/common.js
+++ b/common.js
@@ -189,7 +189,13 @@ module.exports = {
         fs.move(templatePath, tempPath, {clobber: true}, cb)
       },
       function (cb) {
+        // `deref-symlinks` is the default value so we'll use it unless
+        // `derefSymlinks` is defined.
         var shouldDeref = opts['deref-symlinks']
+        if (opts.derefSymlinks !== undefined) {
+          shouldDeref = opts.derefSymlinks
+        }
+
         fs.copy(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: shouldDeref}, cb)
       },
       function (cb) {

--- a/common.js
+++ b/common.js
@@ -19,7 +19,8 @@ function parseCLIArgs (argv) {
       'all',
       'overwrite',
       'strict-ssl',
-      'download.strictSSL'
+      'download.strictSSL',
+      'deref-symlinks'
     ],
     default: {
       'strict-ssl': true,

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,6 +125,12 @@ but are not limited to:
 - `strictSSL` (*Boolean* - default: `true`): Whether SSL certificates are required to be valid when
   downloading Electron.
 
+##### `derefSymlinks`
+
+*Boolean* (default: `true`)
+
+Whether symlinks should be dereferenced during copying.
+
 ##### `icon`
 
 *String*

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,6 +113,12 @@ please use the [`download.cache`](#download) parameter instead)
 
 The directory where prebuilt, pre-packaged Electron downloads are cached.
 
+##### `derefSymlinks`
+
+*Boolean* (default: `true`)
+
+Whether symlinks should be dereferenced during copying.
+
 ##### `download`
 
 *Object*
@@ -124,12 +130,6 @@ but are not limited to:
 - `mirror` (*String*): The URL to override the default Electron download location.
 - `strictSSL` (*Boolean* - default: `true`): Whether SSL certificates are required to be valid when
   downloading Electron.
-
-##### `derefSymlinks`
-
-*Boolean* (default: `true`)
-
-Whether symlinks should be dereferenced during copying.
 
 ##### `icon`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,7 +125,7 @@ but are not limited to:
 - `strictSSL` (*Boolean* - default: `true`): Whether SSL certificates are required to be valid when
   downloading Electron.
 
-##### `derefSymlinks`
+##### `deref-symlinks`
 
 *Boolean* (default: `true`)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,7 +125,7 @@ but are not limited to:
 - `strictSSL` (*Boolean* - default: `true`): Whether SSL certificates are required to be valid when
   downloading Electron.
 
-##### `deref-symlinks`
+##### `derefSymlinks`
 
 *Boolean* (default: `true`)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -541,6 +541,18 @@ test('CLI argument test: --osx-sign=true', function (t) {
   t.end()
 })
 
+test('CLI argument test: --deref-symlinks=false', function (t) {
+  var args = common.parseCLIArgs(['--deref-symlinks=false'])
+  t.equal(args['deref-symlinks'], false)
+  t.end()
+})
+
+test('CLI argument test: --deref-symlinks default', function (t) {
+  var args = common.parseCLIArgs([])
+  t.equal(args['deref-symlinks'], true)
+  t.end()
+})
+
 util.testSinglePlatform('infer test', createInferTest)
 util.testSinglePlatform('defaults test', createDefaultsTest)
 util.testSinglePlatform('default_app.asar removal test', createDefaultAppAsarTest)

--- a/test/basic.js
+++ b/test/basic.js
@@ -474,6 +474,41 @@ function createIgnoreImplicitOutDirTest (opts) {
   }
 }
 
+function createDisableSymlinkDereferencingTest (opts) {
+  return function (t) {
+    t.timeoutAfter(config.timeout)
+
+    opts.name = 'basicTest'
+    opts.dir = path.join(__dirname, 'fixtures', 'basic')
+    opts.out = 'dist'
+    opts.derefSymlinks = false
+    opts.asar = false
+
+    var dst = path.join(opts.dir, 'main-link.js')
+
+    waterfall([
+      function (cb) {
+        var src = path.join(opts.dir, 'main.js')
+        fs.ensureSymlink(src, dst, cb)
+      }, function (cb) {
+        packager(opts, cb)
+      }, function (paths, cb) {
+        var dstLink = path.join(paths[0], 'resources', 'app', 'main-link.js')
+        fs.lstat(dstLink, cb)
+      },
+      function (stats, cb) {
+        t.true(stats.isSymbolicLink(), 'The expected file should still be a symlink.')
+        cb()
+      },
+      function (cb) {
+        fs.remove(dst, cb)
+      }
+    ], function (err) {
+      t.end(err)
+    })
+  }
+}
+
 test('download argument test: download.cache overwrites cache', function (t) {
   var opts = {
     cache: 'should not exist',
@@ -573,6 +608,7 @@ util.testSinglePlatform('tmpdir test', createDisableTmpdirUsingTest)
 util.testSinglePlatform('ignore out dir test', createIgnoreOutDirTest, 'ignoredOutDir')
 util.testSinglePlatform('ignore out dir test: unnormalized path', createIgnoreOutDirTest, './ignoredOutDir')
 util.testSinglePlatform('ignore out dir test: unnormalized path', createIgnoreImplicitOutDirTest)
+util.testSinglePlatform('deref symlink test', createDisableSymlinkDereferencingTest)
 
 util.setup()
 test('fails with invalid arch', function (t) {

--- a/usage.txt
+++ b/usage.txt
@@ -33,6 +33,7 @@ asar-unpack-dir    unpacks the dir to app.asar.unpacked directory whose names gl
 build-version      build version to set for the app
 cache              directory of cached Electron downloads. Defaults to `$HOME/.electron`
                    (Deprecated, use --download.cache instead)
+derefSymlinks      whether symlinks should be dereferenced. Defaults to true.
 download           a list of sub-options to pass to electron-download. They are specified via dot
                    notation, e.g., --download.cache=/tmp/cache
                    Properties supported:

--- a/usage.txt
+++ b/usage.txt
@@ -33,7 +33,7 @@ asar-unpack-dir    unpacks the dir to app.asar.unpacked directory whose names gl
 build-version      build version to set for the app
 cache              directory of cached Electron downloads. Defaults to `$HOME/.electron`
                    (Deprecated, use --download.cache instead)
-derefSymlinks      whether symlinks should be dereferenced. Defaults to true.
+deref-symlinks     whether symlinks should be dereferenced. Defaults to true.
 download           a list of sub-options to pass to electron-download. They are specified via dot
                    notation, e.g., --download.cache=/tmp/cache
                    Properties supported:


### PR DESCRIPTION
:wave: 

We distribute git in our app and git uses relative symlinks to refer to its main executable from some auxiliary executables.

Since `electron-packager` always dereference symlinks, this would end up blowing up the app bundle size by ~180MBs with tons of copies of `git`.

So it’d be great to be able to choose whether symlinks are dereferenced.