### PR TITLE
Skip move if paths resolve to the same location

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -8,6 +8,7 @@ const series = require('run-series')
 const sign = require('electron-osx-sign')
 
 function rename (basePath, oldName, newName, cb) {
+  if (oldName === newName) return cb(null)
   fs.move(path.join(basePath, oldName), path.join(basePath, newName), cb)
 }
 


### PR DESCRIPTION
`fs.move` seems to raise rather than ignore requests for moving/renaming
files from/to the same location. This limits MacOS bundles to be named
"Electron", as the template bundle already has a binary called
"Electron".

This is a potential gotcha which you may want to resolve. It seems like bundling for darwin stumbles if the app is named "Electron". Have a look at the following:

https://github.com/electron-userland/electron-packager/blob/a5222dc4b01685d526506cdd2c54a471c565747a/mac.js#L174

If `appPlist.CFBundleExecutable === "Electron"` this copy/rename operation will fail with an `EEXISTS`. The template for OSX bundles already has the `Electron` binary, so renaming/moving from/to the same path fails.

Personally, I see no reason why you shouldn't be allowed to call your app "Electron" (like in a prototype). Resolving it would save others from wasting their own (and your) time filing bugs and debugging.

> Which version of electron-packager are you using?

    "electron-packager": "^7.2.0"

> What CLI arguments are you passing?

Whatever results in a build of darwin bundles. `--all`, `--platform darwin`, etc...

> What version of [Electron](http://electron.atom.io) are you building with?

"electron-prebuilt": "^1.2.5",

> What is the host platform are you running electron-packager on?

Ubuntu 16.04, x64

> What target platform(s)/architecture(s) are you building for?

Darwin

> Is there a stack trace in the error message you're seeing?

`EEXIST: file already exists, link '/tmp/electron-packager/darwin-x64/Electron-darwin-x64/Electron.app/Contents/MacOS/Electron' -> '/tmp/electron-packager/darwin-x64/Electron-darwin-x64/Electron.app/Contents/MacOS/Electron'`

> Please provide either a failing testcase or detailed steps to reproduce your problem.

Create a project with `{ "name": "Electron" }` in the `package.json`. Build for darwing using either `--all` or `--platform darwin`.
