### PR TITLE
Unify asar options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+* `asar` options can be specified as an `Object` (via the API) or with dot notation (via the CLI) -
+  see the respective docs for details (#353, #417)
+
+### Deprecated
+
+* `asar-unpack` is deprecated in favor of `asar.unpack` (#417)
+* `asar-unpack-dir` is deprecated in favor of `asar.unpackDir` (#417)
+
 ## [7.2.0] - 2016-07-03
 
 ### Added

--- a/common.js
+++ b/common.js
@@ -217,13 +217,19 @@ module.exports = {
 
     if (opts.asar) {
       operations.push(function (cb) {
-        var asarOptions = {}
-        if (opts['asar-unpack']) {
-          asarOptions.unpack = opts['asar-unpack']
+        if (opts.hasOwnProperty('asar-unpack')) {
+          console.warn('The asar-unpack parameter is deprecated, use asar-options.unpack instead')
         }
-        if (opts['asar-unpack-dir']) {
-          asarOptions.unpackDir = opts['asar-unpack-dir']
+
+        if (opts.hasOwnProperty('asar-unpack-dir')) {
+          console.warn('The asar-unpack-dir parameter is deprecated, use asar-options.unpackDir instead')
         }
+
+        var asarOptions = Object.assign({
+          unpack: opts['asar-unpack'],
+          unpackDir: opts['asar-unpack-dir']
+        }, opts['asar-options'])
+
         asarApp(path.join(appPath), asarOptions, cb)
       })
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,24 +81,22 @@ The release version of the application. Maps to the `ProductVersion` metadata pr
 
 Whether to package the application's source code into an archive, using [Electron's archive format](https://github.com/electron/asar). Reasons why you may want to enable this feature are described in [an application packaging tutorial in Electron's documentation](http://electron.atom.io/docs/v0.36.0/tutorial/application-packaging/).
 
-##### `asar-unpack`
+##### `asar-options`
 
-*String*
+*Object*
 
-A [glob expression](https://github.com/isaacs/minimatch#features), when specified, unpacks the file with matching names to the `app.asar.unpacked` directory.
+If present, passes custom options to [`asar`](https://www.npmjs.com/package/asar) when packaging.
+Supported parameters include, but are not limited to:
+- `unpack` (*String*): A [glob expression](https://github.com/isaacs/minimatch#features), when specified, unpacks the file with matching names to the `app.asar.unpacked` directory.
+- `unpack-dir` (*String*): Unpacks the dir to `app.asar.unpacked` directory whose names exactly or pattern match this string. The `asar-unpack-dir` is relative to `dir`.
 
-##### `asar-unpack-dir`
+  Some examples:
 
-*String*
-
-Unpacks the dir to `app.asar.unpacked` directory whose names exactly or pattern match this string. The `asar-unpack-dir` is relative to `dir`.
-
-Some examples:
-
-- `asar-unpack-dir=sub_dir` will unpack the directory `/<dir>/sub_dir`
-- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`, but it will note include their subdirectories.
-- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
-- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
+  - `asar-unpack-dir=sub_dir` will unpack the directory `/<dir>/sub_dir`
+  - `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`, but it will note include their subdirectories.
+  - `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
+  - `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
+- `ordering` (*String*): A path to an ordering file for packing files. See an explanation [here](https://github.com/atom/atom/issues/10163)
 
 ##### `build-version`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -77,26 +77,40 @@ The release version of the application. Maps to the `ProductVersion` metadata pr
 
 ##### `asar`
 
-*Boolean* (default: `false`)
+*Boolean* or *Object* (default: `false`)
 
-Whether to package the application's source code into an archive, using [Electron's archive format](https://github.com/electron/asar). Reasons why you may want to enable this feature are described in [an application packaging tutorial in Electron's documentation](http://electron.atom.io/docs/v0.36.0/tutorial/application-packaging/).
-
-##### `asar-options`
-
-*Object*
-
-If present, passes custom options to [`asar`](https://www.npmjs.com/package/asar) when packaging.
-Supported parameters include, but are not limited to:
+Whether to package the application's source code into an archive, using [Electron's archive format](https://github.com/electron/asar). Reasons why you may want to enable this feature are described in [an application packaging tutorial in Electron's documentation](http://electron.atom.io/docs/v0.36.0/tutorial/application-packaging/). When the value is `true`, pass default configuration to the `asar` module. The configuration values listed below can be customized when the value is an `Object`. Supported parameters include, but are not limited to:
+- `ordering` (*String*): A path to an ordering file for packing files. An explanation can be found on the [Atom issue tracker](https://github.com/atom/atom/issues/10163).
 - `unpack` (*String*): A [glob expression](https://github.com/isaacs/minimatch#features), when specified, unpacks the file with matching names to the `app.asar.unpacked` directory.
-- `unpack-dir` (*String*): Unpacks the dir to `app.asar.unpacked` directory whose names exactly or pattern match this string. The `asar-unpack-dir` is relative to `dir`.
+- `unpackDir` (*String*): Unpacks the dir to the `app.asar.unpacked` directory whose names exactly or pattern match this string. The `asar.unpackDir` is relative to `dir`.
 
   Some examples:
 
-  - `asar-unpack-dir=sub_dir` will unpack the directory `/<dir>/sub_dir`
-  - `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`, but it will note include their subdirectories.
-  - `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
-  - `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
-- `ordering` (*String*): A path to an ordering file for packing files. See an explanation [here](https://github.com/atom/atom/issues/10163)
+  - `asar.unpackDir = 'sub_dir'` will unpack the directory `/<dir>/sub_dir`
+  - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/*'` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`, but it will not include their subdirectories.
+  - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/**'` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
+  - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*'` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
+
+##### `asar-unpack`
+
+*String* (**deprecated** and will be removed in a future major version,
+please use the [`asar.unpack`](#asar) parameter instead)
+
+A [glob expression](https://github.com/isaacs/minimatch#features), when specified, unpacks the file with matching names to the `app.asar.unpacked` directory.
+
+##### `asar-unpack-dir`
+
+*String* (**deprecated** and will be removed in a future major version,
+please use the [`asar.unpackDir`](#asar) parameter instead)
+
+Unpacks the dir to `app.asar.unpacked` directory whose names exactly or pattern match this string. The `asar-unpack-dir` is relative to `dir`.
+
+Some examples:
+
+- `asar-unpack-dir=sub_dir` will unpack the directory `/<dir>/sub_dir`
+- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`, but it will note include their subdirectories.
+- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
+- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
 
 ##### `build-version`
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -147,8 +147,10 @@ function createAsarTest (opts) {
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.asar = true
-    opts['asar-unpack'] = '*.pac'
-    opts['asar-unpack-dir'] = 'dir_to_unpack'
+    opts['asar-options'] = {
+      'unpack': '*.pac',
+      'unpackDir': 'dir_to_unpack'
+    }
     var finalPath
     var resourcesPath
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -146,8 +146,7 @@ function createAsarTest (opts) {
 
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
-    opts.asar = true
-    opts['asar-options'] = {
+    opts.asar = {
       'unpack': '*.pac',
       'unpackDir': 'dir_to_unpack'
     }
@@ -511,6 +510,82 @@ function createDisableSymlinkDereferencingTest (opts) {
   }
 }
 
+test('asar argument test: asar is not set', function (t) {
+  var opts = {}
+
+  var asarOpts = common.createAsarOpts(opts)
+  t.false(asarOpts, 'createAsarOpts returns false')
+  t.end()
+})
+
+test('asar argument test: asar is true', function (t) {
+  var opts = {
+    asar: true
+  }
+
+  var asarOpts = common.createAsarOpts(opts)
+  t.same(asarOpts, {unpack: undefined, unpackDir: undefined})
+  t.end()
+})
+
+test('asar argument test: asar is not an Object or a bool', function (t) {
+  var opts = {
+    asar: 'string'
+  }
+
+  var asarOpts = common.createAsarOpts(opts)
+  t.false(asarOpts, 'createAsarOpts returns false')
+  t.end()
+})
+
+test('asar argument test: asar-unpack still works albeit deprecated', function (t) {
+  var opts = {
+    asar: true,
+    'asar-unpack': 'deprecated'
+  }
+
+  var asarOpts = common.createAsarOpts(opts)
+  t.same(asarOpts, {unpack: 'deprecated', unpackDir: undefined})
+  t.end()
+})
+
+test('asar argument test: asar.unpack overwrites asar-unpack', function (t) {
+  var opts = {
+    asar: {
+      unpack: 'should exist'
+    },
+    'asar-unpack': 'should not exist'
+  }
+
+  var asarOpts = common.createAsarOpts(opts)
+  t.same(asarOpts, {unpack: 'should exist', unpackDir: undefined})
+  t.end()
+})
+
+test('asar argument test: asar-unpack-dir still works albeit deprecated', function (t) {
+  var opts = {
+    asar: true,
+    'asar-unpack-dir': 'deprecated'
+  }
+
+  var asarOpts = common.createAsarOpts(opts)
+  t.same(asarOpts, {unpack: undefined, unpackDir: 'deprecated'})
+  t.end()
+})
+
+test('asar argument test: asar.unpackDir overwrites asar-unpack-dir', function (t) {
+  var opts = {
+    asar: {
+      unpackDir: 'should exist'
+    },
+    'asar-unpack-dir': 'should not exist'
+  }
+
+  var asarOpts = common.createAsarOpts(opts)
+  t.same(asarOpts, {unpack: undefined, unpackDir: 'should exist'})
+  t.end()
+})
+
 test('download argument test: download.cache overwrites cache', function (t) {
   var opts = {
     cache: 'should not exist',
@@ -566,15 +641,21 @@ test('CLI argument test: --download.strictSSL default', function (t) {
   t.end()
 })
 
-test('CLI argument test: --tmpdir=false', function (t) {
-  var args = common.parseCLIArgs(['--tmpdir=false'])
-  t.equal(args.tmpdir, false)
+test('CLI argument test: --asar=true', function (t) {
+  var args = common.parseCLIArgs(['--asar=true'])
+  t.equal(args.asar, true)
   t.end()
 })
 
 test('CLI argument test: --osx-sign=true', function (t) {
   var args = common.parseCLIArgs(['--osx-sign=true'])
   t.equal(args['osx-sign'], true)
+  t.end()
+})
+
+test('CLI argument test: --tmpdir=false', function (t) {
+  var args = common.parseCLIArgs(['--tmpdir=false'])
+  t.equal(args.tmpdir, false)
   t.end()
 })
 

--- a/usage.txt
+++ b/usage.txt
@@ -26,10 +26,13 @@ appname            the name of the app, if it needs to be different from the "pr
 app-copyright      human-readable copyright line for the app
 app-version        release version to set for the app
 asar               packages the source code within your app into an archive
-asar-unpack        unpacks the files to app.asar.unpacked directory whose filenames regex .match
-                   this string
-asar-unpack-dir    unpacks the dir to app.asar.unpacked directory whose names glob pattern or
-                   exactly match this string. It's relative to the <sourcedir>.
+asar-options       a list of sub-options to pass to asar. They are specified via dot notation, e.g.,
+                   --asar-options.unpackDir=sub_dir
+                   Properties supported:
+                   - unpack: unpacks the files to app.asar.unpacked directory whose filenames regex
+                     match this string
+                  - unpackDir: unpacks the dir to app.asar.unpacked directory whose names glob
+                     pattern or exactly match this string. It's relative to the <sourcedir>.
 build-version      build version to set for the app
 cache              directory of cached Electron downloads. Defaults to `$HOME/.electron`
                    (Deprecated, use --download.cache instead)

--- a/usage.txt
+++ b/usage.txt
@@ -25,14 +25,22 @@ appname            the name of the app, if it needs to be different from the "pr
 
 app-copyright      human-readable copyright line for the app
 app-version        release version to set for the app
-asar               packages the source code within your app into an archive
-asar-options       a list of sub-options to pass to asar. They are specified via dot notation, e.g.,
-                   --asar-options.unpackDir=sub_dir
+asar               whether to package the source code within your app into an archive. You can either
+                   pass --asar by itself to use the default configuration, or use dot notation to
+                   configure a list of sub-properties, e.g. --asar.unpackDir=sub_dir
+
                    Properties supported:
-                   - unpack: unpacks the files to app.asar.unpacked directory whose filenames regex
-                     match this string
-                  - unpackDir: unpacks the dir to app.asar.unpacked directory whose names glob
+                   - ordering: path to an ordering file for file packing
+                   - unpack: unpacks the files to the app.asar.unpacked directory whose filenames
+                     regex .match this string
+                   - unpackDir: unpacks the dir to the app.asar.unpacked directory whose names glob
                      pattern or exactly match this string. It's relative to the <sourcedir>.
+asar-unpack        unpacks the files to the app.asar.unpacked directory whose filenames regex .match
+                   this string
+                   (Deprecated, use asar.unpack instead)
+asar-unpack-dir    unpacks the dir to the app.asar.unpacked directory whose names glob pattern or
+                   exactly match this string. It's relative to the <sourcedir>.
+                   (Deprecated, use asar.unpackDir instead)
 build-version      build version to set for the app
 cache              directory of cached Electron downloads. Defaults to `$HOME/.electron`
                    (Deprecated, use --download.cache instead)


### PR DESCRIPTION
This is a continuation of #353, but it is rebased against master, merges `asar-options` into `asar`, and adds tests.

It only enhances `asar` and deprecates `asar-unpack` and `asar-unpack-dir`, so only a minor version bump is required.

Closes #353.

## TODO
* [x] Add NEWS entries