### PR TITLE
Add support for the new `electron` package name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,31 @@ commit 2: add bar option
 If you are continuing the work of another person's PR and need to rebase/squash, please retain the
 attribution of the original author(s) and continue the work in subsequent commits.
 
+### Running tests
+
+To run the test suite on your local machine, you'll first need to do a little
+setup.
+
+If you're using macOS:
+
+```sh
+TRAVIS_OS_NAME=osx ./test/ci/before_install.sh
+```
+
+If you're using a Debian/Ubuntu-derived distribution of Linux with x86_64
+architecture:
+
+```sh
+TRAVIS_OS_NAME=linux ./test/ci/before_install.sh
+```
+
+Then you can install dependencies and run the suite:
+
+```sh
+npm install
+npm test
+```
+
 ### Creating test fixtures
 
 For some unit tests, a test fixture Electron project is required. Sometimes it's OK to use an

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [7.5.0] - 2016-08-04
+
+### Added
+
+* Support the new `electron` package name (#435)
+
 ## [7.4.0] - 2016-07-31
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -171,6 +171,7 @@ described after the list*):
 
 * the directory specified by the [`out`](#out) parameter
 * `node_modules/.bin`
+* `node_modules/electron`
 * `node_modules/electron-prebuilt`
 * `node_modules/electron-packager`
 * `.git`
@@ -228,8 +229,7 @@ The base directory to use as a temp directory. Set to `false` to disable use of 
 The Electron version with which the app is built (without the leading 'v') - for example,
 [`0.33.9`](https://github.com/electron/electron/releases/tag/v0.33.9). See [Electron releases] for
 valid versions. If omitted, it will use the version of the nearest local installation of
-`electron-prebuilt`, defined in `package.json` in either `dependencies` or `devDependencies`.
-
+`electron` or `electron-prebuilt`, defined in `package.json` in either `dependencies` or `devDependencies`.
 
 #### OS X/Mac App Store targets only
 
@@ -253,7 +253,7 @@ Valid values are listed in [Apple's documentation](https://developer.apple.com/l
 
 *String*
 
-Filename of a plist file; the contents are added to the app's plist. Entries in `extend-info` override entries in the base plist file supplied by `electron-prebuilt`, but are overridden by other explicit arguments such as [`app-version`](#app-version) or [`app-bundle-id`](#app-bundle-id).
+Filename of a plist file; the contents are added to the app's plist. Entries in `extend-info` override entries in the base plist file supplied by `electron` or `electron-prebuilt`, but are overridden by other explicit arguments such as [`app-version`](#app-version) or [`app-bundle-id`](#app-bundle-id).
 
 ##### `extra-resource`
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "electron-osx-sign": "^0.3.0",
     "extract-zip": "^1.0.3",
     "fs-extra": "^0.30.0",
-    "get-package-info": "^0.0.3",
+    "lodash.get": "^4.4.1",
     "minimist": "^1.1.1",
     "plist": "^1.1.0",
     "rcedit": "^0.5.1",
@@ -42,6 +42,7 @@
     "rcinfo": "^0.1.3",
     "rimraf": "^2.3.2",
     "run-waterfall": "^1.1.1",
+    "tap-spec": "^4.1.1",
     "tape": "^4.0.0"
   },
   "engines": {
@@ -50,7 +51,7 @@
   "scripts": {
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "pretest": "rimraf test/work",
-    "test": "eslint . && nyc --cache tape test"
+    "test": "eslint . && nyc --cache tape test | tap-spec"
   },
   "directories": {
     "test": "test"

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,8 @@ electron-packager . --all
 
 * Use the current directory for the `sourcedir`
 * Infer the `appname` from the `productName` in `package.json`
-* Download [all supported target platforms and arches](#supported-platforms) of Electron using the installed `electron-prebuilt` version (and cache the downloads in `~/.electron`)
+* Download [all supported target platforms and arches](#supported-platforms) of Electron
+using the installed `electron` or `electron-prebuilt` version (and cache the downloads in `~/.electron`)
 * For the `darwin` build, as an example:
   * build the OS X `Foo Bar.app`
   * place `Foo Bar.app` in `foobar/Foo Bar-darwin-x64/` (since an `out` directory was not specified, it used the current working directory)

--- a/test/basic.js
+++ b/test/basic.js
@@ -193,7 +193,7 @@ function createOverwriteTest (opts) {
   }
 }
 
-function createInferTest (opts) {
+function createInferElectronPrebuiltTest (opts) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
@@ -230,6 +230,25 @@ function createInferTest (opts) {
         cb()
       }
     ], function (err) {
+      t.end(err)
+    })
+  }
+}
+
+function createInferElectronTest (opts) {
+  return function (t) {
+    console.error('start createInferElectronTest')
+    t.timeoutAfter(config.timeout)
+
+    // Don't specify name or version
+    delete opts.version
+    opts.dir = path.join(__dirname, 'fixtures', 'basic-renamed-to-electron')
+
+    var packageJSON = require(path.join(opts.dir, 'package.json'))
+
+    packager(opts, function (err, paths) {
+      var version = fs.readFileSync(path.join(paths[0], 'version'), 'utf8')
+      t.equal(`v${packageJSON.devDependencies['electron']}`, version.toString(), 'The version should be inferred from installed `electron` version')
       t.end(err)
     })
   }
@@ -385,7 +404,8 @@ test('download argument test: download.{arch,platform,version} does not overwrit
   t.end()
 })
 
-util.testSinglePlatform('infer test', createInferTest)
+util.testSinglePlatform('infer test using `electron-prebuilt` package', createInferElectronPrebuiltTest)
+util.testSinglePlatform('infer test using `electron` package', createInferElectronTest)
 util.testSinglePlatform('infer missing fields test', createInferMissingFieldsTest)
 util.testSinglePlatform('infer with bad fields test', createInferWithBadFieldsTest)
 util.testSinglePlatform('defaults test', createDefaultsTest)

--- a/test/fixtures/basic-renamed-to-electron/index.html
+++ b/test/fixtures/basic-renamed-to-electron/index.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+	<body>Hello, world!</body>
+</html>

--- a/test/fixtures/basic-renamed-to-electron/main.js
+++ b/test/fixtures/basic-renamed-to-electron/main.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const app = require('app')
+const BrowserWindow = require('browser-window')
+let mainWindow
+
+app.on('window-all-closed', function () {
+  app.quit()
+})
+
+app.on('ready', function () {
+  mainWindow = new BrowserWindow({
+    center: true,
+    title: 'Basic Test',
+    width: 800,
+    height: 600
+  })
+
+  mainWindow.loadUrl('file://' + require('path').resolve(__dirname, 'index.html'))
+
+  mainWindow.on('closed', function () {
+    mainWindow = null
+  })
+})

--- a/test/fixtures/basic-renamed-to-electron/package.json
+++ b/test/fixtures/basic-renamed-to-electron/package.json
@@ -1,0 +1,12 @@
+{
+  "main": "main.js",
+  "productName": "MainJS",
+  "description": "A test of the renamed from `electron-prebuilt` to `electron`",
+  "dependencies": {
+    "electron-prebuilt": "1.2.0"
+  },
+  "devDependencies": {
+    "electron": "1.3.1",
+    "electron-prebuilt": "1.3.0"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,9 @@ series([
     console.log('Running npm install in fixtures/basic...')
     exec('npm install', {cwd: util.fixtureSubdir('basic')}, cb)
   }, function (cb) {
+    console.log('Running npm install in fixtures/basic-renamed-to-electron...')
+    exec('npm install', {cwd: util.fixtureSubdir('basic-renamed-to-electron')}, cb)
+  }, function (cb) {
     console.log('Running npm install in fixtures/el-0374...')
     exec('npm install', {cwd: util.fixtureSubdir('el-0374')}, cb)
   }


### PR DESCRIPTION
A rename of `electron-prebuilt` to `electron` is in the works: https://github.com/electron-userland/electron-prebuilt/issues/160

Both`electron-prebuilt` and `electron` will be published in tandem through the end of 2016.

This PR updates `electron-packager` to add support for users of the `electron` package, while maintaining existing functionality for `electron-prebuilt`.

@kevinsawicki @jlord @zcbenz @iolsen
