### PR TITLE
Fix dir of getNameAndVersion for require package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ function validateList (list, supported, name) {
 
 function getNameAndVersion (opts, dir, cb) {
   var pkg = require(path.join(dir, 'package.json'))
-  if (!pkg) return cb(Error(`no package.json file found in ${dir}`))
 
   // Name and version provided, no need to infer
   if (opts.name && opts.version) return cb(null)
@@ -204,7 +203,7 @@ module.exports = function packager (opts, cb) {
   debug(`Target Platforms: ${platforms.join(', ')}`)
   debug(`Target Architectures: ${archs.join(', ')}`)
 
-  getNameAndVersion(opts, opts.dir || process.cwd(), function (err) {
+  getNameAndVersion(opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {
     if (err) {
       err.message = 'Unable to determine application name or Electron version. ' +
         'Please specify an application name and Electron version.\n\n' +

--- a/test/basic.js
+++ b/test/basic.js
@@ -466,3 +466,19 @@ test('fails with invalid version', function (t) {
   })
 })
 util.teardown()
+
+util.setup()
+test('dir argument test: should work with relative path', function (t) {
+  var opts = {
+    name: 'ElectronTest',
+    dir: path.join('..', 'fixtures', 'el-0374'),
+    version: '0.37.4',
+    arch: 'x64',
+    platform: 'linux'
+  }
+  packager(opts, function (err, paths) {
+    t.equal(path.join(__dirname, 'work', 'ElectronTest-linux-x64'), paths[0], 'paths returned')
+    t.end(err)
+  })
+})
+util.teardown()


### PR DESCRIPTION
Related to https://github.com/electron-userland/electron-packager/issues/439.

Also, we don't need to check `!pkg`, because it will throw `module not found` error if no package.json file found.