### PR TITLE
CLI: ensure --out has either a string or null value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* [CLI] ensure --out has either a string or null value (#442)
+
 ## [7.5.1] - 2016-08-06
 
 ### Fixed

--- a/common.js
+++ b/common.js
@@ -26,7 +26,10 @@ function parseCLIArgs (argv) {
       'deref-symlinks': true,
       'download.strictSSL': true,
       'strict-ssl': true
-    }
+    },
+    string: [
+      'out'
+    ]
   })
 
   args.dir = args._[0]
@@ -39,6 +42,10 @@ function parseCLIArgs (argv) {
     args.protocols = protocolSchemes.map(function (scheme, i) {
       return {schemes: [scheme], name: protocolNames[i]}
     })
+  }
+
+  if (args.out === '') {
+    args.out = null
   }
 
   // Overrides for multi-typed arguments, because minimist doesn't support it

--- a/test/cli.js
+++ b/test/cli.js
@@ -46,3 +46,15 @@ test('CLI argument test: --deref-symlinks default', function (t) {
   t.equal(args['deref-symlinks'], true)
   t.end()
 })
+
+test('CLI argument test: --out always resolves to a string', (t) => {
+  var args = common.parseCLIArgs(['--out=1'])
+  t.equal(args.out, '1')
+  t.end()
+})
+
+test('CLI argument test: --out without a value is the same as not passing --out', (t) => {
+  var args = common.parseCLIArgs(['--out'])
+  t.equal(args.out, null)
+  t.end()
+})


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

Closes #386.

This uses a different approach from #386, in that it only handles typecasting for the CLI and not the API. Additionally, it assumes that `--out` without a value is the same as omitting `--out`.

CC: @sethlu

**Are your changes appropriately documented?**

Added NEWS entry

**Do your changes have sufficient test coverage?**

Yes (see `test/cli.js`)


**Did the testsuite pass successfully on your local machine?**

Yes