### PR TITLE
fix version inference regression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * [CLI] ensure --out has either a string or null value (#442)
+* Use `get-package-info` (again) to support finding prebuilt in parent directories (#445)
 
 ## [7.5.1] - 2016-08-06
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const debug = require('debug')('electron-packager')
 const download = require('electron-download')
 const extract = require('extract-zip')
 const fs = require('fs-extra')
-const prop = require('lodash.get')
+const getPackageInfo = require('get-package-info')
 const metadata = require('./package.json')
 const os = require('os')
 const path = require('path')
@@ -49,28 +49,46 @@ function validateList (list, supported, name) {
 }
 
 function getNameAndVersion (opts, dir, cb) {
-  var pkg = require(path.join(dir, 'package.json'))
+  var props = []
+  if (!opts.name) props.push(['productName', 'name'])
+  if (!opts.version) props.push(['dependencies.electron', 'devDependencies.electron'])
 
   // Name and version provided, no need to infer
-  if (opts.name && opts.version) return cb(null)
+  if (props.length === 0) return cb(null)
 
-  // Infer name from package.json
-  opts.name = opts.name || prop(pkg, 'productName') || prop(pkg, 'name')
-
-  // Infer electron version from package.json
-  var electronVersion = prop(pkg, 'dependencies.electron') || prop(pkg, 'devDependencies.electron')
-  var electronPrebuiltVersion = prop(pkg, 'dependencies.electron-prebuilt') || prop(pkg, 'devDependencies.electron-prebuilt')
-  opts.version = opts.version || electronVersion || electronPrebuiltVersion
-
-  if (!electronVersion && !electronPrebuiltVersion) return cb(null)
-
-  var packageName = electronVersion ? 'electron' : 'electron-prebuilt'
-  resolve(packageName, {basedir: dir}, function (err, res, pkg) {
-    if (err) return cb(err)
-    debug('Inferring target Electron version from `' + packageName + '` dependency or devDependency in package.json')
-    opts.version = pkg.version
-    return cb(null)
+  // Search package.json files to infer name and version from
+  getPackageInfo(props, dir, function (err, result) {
+    if (err) {
+      // `get-package-info` exploded looking for `electron`. Try `electron-prebuilt` instead
+      props.pop()
+      props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt'])
+      getPackageInfo(props, dir, function (err, result) {
+        if (err) return cb(err)
+        return inferNameAndVersionFromInstalled('electron-prebuilt', opts, result, cb)
+      })
+    } else {
+      return inferNameAndVersionFromInstalled('electron', opts, result, cb)
+    }
   })
+}
+
+function inferNameAndVersionFromInstalled (packageName, opts, result, cb) {
+  if (result.values.productName) {
+    debug('Inferring application name from productName or name in package.json')
+    opts.name = result.values.productName
+  }
+  if (result.values[`dependencies.${packageName}`]) {
+    resolve(packageName, {
+      basedir: path.dirname(result.source[`dependencies.${packageName}`].src)
+    }, function (err, res, pkg) {
+      if (err) return cb(err)
+      debug(`Inferring target Electron version from ${packageName} dependency or devDependency in package.json`)
+      opts.version = pkg.version
+      return cb(null)
+    })
+  } else {
+    return cb(null)
+  }
 }
 
 function createSeries (opts, archs, platforms) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "electron-osx-sign": "^0.3.0",
     "extract-zip": "^1.0.3",
     "fs-extra": "^0.30.0",
-    "lodash.get": "^4.4.1",
+    "get-package-info": "^0.1.0",
     "minimist": "^1.1.1",
     "plist": "^1.1.0",
     "rcedit": "^0.5.1",


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-packager/issues/441

This brings `get-package-info` back into the mix, so directories are properly traversed for `package.json` files containing `electron` or `electron-prebuilt`. The work is broken up into two functions now to work around the [`resolve` issue](https://github.com/substack/node-resolve/pull/81) that causes an error to be thrown when a given set of props are not found.

cc @malept @kevinsawicki 