### PR TITLE
Remove unnecessary second get-package-json call

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,38 +51,37 @@ function validateList (list, supported, name) {
 function getNameAndVersion (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
-  if (!opts.version) props.push(['dependencies.electron', 'devDependencies.electron'])
+  if (!opts.version) {
+    props.push([
+      'dependencies.electron',
+      'devDependencies.electron',
+      'dependencies.electron-prebuilt',
+      'devDependencies.electron-prebuilt'
+    ])
+  }
 
   // Name and version provided, no need to infer
   if (props.length === 0) return cb(null)
 
   // Search package.json files to infer name and version from
   getPackageInfo(props, dir, function (err, result) {
-    if (err) {
-      // `get-package-info` exploded looking for `electron`. Try `electron-prebuilt` instead
-      props.pop()
-      props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt'])
-      getPackageInfo(props, dir, function (err, result) {
-        if (err) return cb(err)
-        return inferNameAndVersionFromInstalled('electron-prebuilt', opts, result, cb)
-      })
-    } else {
-      return inferNameAndVersionFromInstalled('electron', opts, result, cb)
-    }
+    if (err) return cb(err)
+    return inferNameAndVersionFromInstalled(opts, result, cb)
   })
 }
 
-function inferNameAndVersionFromInstalled (packageName, opts, result, cb) {
+function inferNameAndVersionFromInstalled (opts, result, cb) {
   if (result.values.productName) {
     debug('Inferring application name from productName or name in package.json')
     opts.name = result.values.productName
   }
-  if (result.values[`dependencies.${packageName}`]) {
+  if (result.values['dependencies.electron']) {
+    var packageName = result.source['dependencies.electron'].prop.split('.')[1]
     resolve(packageName, {
-      basedir: path.dirname(result.source[`dependencies.${packageName}`].src)
+      basedir: path.dirname(result.source['dependencies.electron'].src)
     }, function (err, res, pkg) {
       if (err) return cb(err)
-      debug(`Inferring target Electron version from ${packageName} dependency or devDependency in package.json`)
+      debug(`Inferring target Electron version from ${result.source['dependencies.electron'].prop} in package.json`)
       opts.version = pkg.version
       return cb(null)
     })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "electron-osx-sign": "^0.3.0",
     "extract-zip": "^1.0.3",
     "fs-extra": "^0.30.0",
-    "get-package-info": "0.0.3",
+    "get-package-info": "^0.1.0",
     "minimist": "^1.1.1",
     "plist": "^1.1.0",
     "rcedit": "^0.5.1",


### PR DESCRIPTION
Cleanup PR for #445. Takes advantage of `get-package-info@0.1.0` to get the source prop that provided the inferred electron version without having to make two calls.

The inference tests passed for me but a couple codesign tests failed. I hope that's just my machine.