### PR TITLE
Add a hook for afterCopy

### DIFF
--- a/common.js
+++ b/common.js
@@ -241,6 +241,14 @@ module.exports = {
         fs.copy(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: shouldDeref}, cb)
       },
       function (cb) {
+        var afterCopyHooks = (opts.afterCopy || []).map(function (afterCopyFn) {
+          return function (cb) {
+            afterCopyFn(appPath, opts.version, opts.platform, opts.arch, cb)
+          }
+        })
+        series(afterCopyHooks, cb)
+      },
+      function (cb) {
         // Support removing old default_app folder that is now an asar archive
         fs.remove(path.join(resourcesPath, 'default_app'), cb)
       },

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,6 +45,18 @@ The non-`all` values correspond to the platform names used by [Electron releases
 
 #### All Platforms
 
+##### `afterCopy`
+
+*Array of Functions*
+
+An array of functions to be called after your app directory has been copied to a temporary directory.  Each function is called with five parameters:
+
+- `buildPath` (*String*): The path to the temporary folder where your app has been copied to
+- `electronVersion` (*String*): The version of electron you are packaging for
+- `platform` (*String*): The target platform you are packaging for
+- `arch` (*String*): The target architecture you are packaging for
+- `callback` (*Function*): Must be called once you have completed your actions
+
 ##### `afterExtract`
 
 *Array of Functions*

--- a/index.js
+++ b/index.js
@@ -155,6 +155,8 @@ function createSeries (opts, archs, platforms) {
         var comboOpts = Object.create(opts)
         comboOpts.arch = arch
         comboOpts.platform = platform
+        comboOpts.version = version
+        comboOpts.afterCopy = opts.afterCopy
 
         if (!useTempDir) {
           createApp(comboOpts)

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -22,38 +22,44 @@ function verifyPackageExistence (finalPaths, callback) {
   })
 }
 
-util.setup()
-test('platform=all test (one arch) (afterExtract hook)', function (t) {
-  t.timeoutAfter(config.timeout * 2) // 2 packages will be built during this test
+function createHookTest (hookName) {
+  util.setup()
+  test('platform=all test (one arch) (' + hookName + ' hook)', function (t) {
+    t.timeoutAfter(config.timeout * 2) // 2 packages will be built during this test
 
-  var afterExtractCalled = false
-  var opts = {
-    name: 'basicTest',
-    dir: util.fixtureSubdir('basic'),
-    version: config.version,
-    arch: 'ia32',
-    platform: 'all',
-    afterExtract: [function testAfterExtract (buildPath, electronVersion, platform, arch, callback) {
-      afterExtractCalled = true
-      t.equal(electronVersion, opts.version, 'afterExtract electronVersion should be the same as the options object')
-      t.equal(arch, opts.arch, 'afterExtract arch should be the same as the options object')
+    var hookCalled = false
+    var opts = {
+      name: 'basicTest',
+      dir: util.fixtureSubdir('basic'),
+      version: config.version,
+      arch: 'ia32',
+      platform: 'all'
+    }
+
+    opts[hookName] = [function testHook (buildPath, electronVersion, platform, arch, callback) {
+      hookCalled = true
+      t.equal(electronVersion, opts.version, hookName + ' electronVersion should be the same as the options object')
+      t.equal(arch, opts.arch, hookName + ' arch should be the same as the options object')
       callback()
     }]
-  }
 
-  waterfall([
-    function (cb) {
-      packager(opts, cb)
-    }, function (finalPaths, cb) {
-      t.equal(finalPaths.length, 2, 'packager call should resolve with expected number of paths')
-      t.true(afterExtractCalled, 'afterExtract methods should have been called')
-      verifyPackageExistence(finalPaths, cb)
-    }, function (exists, cb) {
-      t.true(exists, 'Packages should be generated for both 32-bit platforms')
-      cb()
-    }
-  ], function (err) {
-    t.end(err)
+    waterfall([
+      function (cb) {
+        packager(opts, cb)
+      }, function (finalPaths, cb) {
+        t.equal(finalPaths.length, 2, 'packager call should resolve with expected number of paths')
+        t.true(hookCalled, hookName + ' methods should have been called')
+        verifyPackageExistence(finalPaths, cb)
+      }, function (exists, cb) {
+        t.true(exists, 'Packages should be generated for both 32-bit platforms')
+        cb()
+      }
+    ], function (err) {
+      t.end(err)
+    })
   })
-})
-util.teardown()
+  util.teardown()
+}
+
+createHookTest('afterCopy')
+createHookTest('afterExtract')


### PR DESCRIPTION
* Hook runs once your app dir has been copied to a temp dir
* No hook has no effect (install async callback)
* Generalized the afterExtract test to easily add an afterCopy test

The main use case for this hook is to run `electron-rebuild` or a simply `node-gyp` rebuild script against the **copied** `node_modules` folder.

TLDR: This will make rebuilding `node_modules` for Electron very easy now 👍 (Once I get around to hooking `electron-rebuild` into this)