### PR TITLE
Infer --app-version from package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 test/work
 .DS_Store
 .nyc_output
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ env:
     - secure: hG3cs8/tOGTa8IPewVuahcp1f8gwsk/rX7ReUBPag6cdZdJpkbjzxp8R97mhhCrFOP/fvX8zAbCelXvvhME/mjZTFgzSNHLBL/SJreHP5m2B1yxXkroiQFu1qwewvzzKmfcs5W1CD8J8WbJuBk9zozDQG9c1OxTaK87tBGh1xik=
     # prevent wine popup dialogs about installing additional packages
     - WINEDLLOVERRIDES="mscoree,mshtml="
+    - WINEDEBUG="-all"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,6 @@ branches:
 env:
   global:
     # coveralls token
-    secure: hG3cs8/tOGTa8IPewVuahcp1f8gwsk/rX7ReUBPag6cdZdJpkbjzxp8R97mhhCrFOP/fvX8zAbCelXvvhME/mjZTFgzSNHLBL/SJreHP5m2B1yxXkroiQFu1qwewvzzKmfcs5W1CD8J8WbJuBk9zozDQG9c1OxTaK87tBGh1xik=
+    - secure: hG3cs8/tOGTa8IPewVuahcp1f8gwsk/rX7ReUBPag6cdZdJpkbjzxp8R97mhhCrFOP/fvX8zAbCelXvvhME/mjZTFgzSNHLBL/SJreHP5m2B1yxXkroiQFu1qwewvzzKmfcs5W1CD8J8WbJuBk9zozDQG9c1OxTaK87tBGh1xik=
+    # prevent wine popup dialogs about installing additional packages
+    - WINEDLLOVERRIDES="mscoree,mshtml="

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-* The `package.json` `version` property is the default app version if `--app-version` is unspecified.
+* The `package.json` `version` property is the default app version if `--app-version` is unspecified (#449)
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* The `package.json` `version` property is the default app version if `--app-version` is unspecified.
+
 ### Fixed
 
 * [CLI] ensure --out has either a string or null value (#442)

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,7 +85,7 @@ The human-readable copyright line for the app. Maps to the `LegalCopyright` meta
 
 *String*
 
-The release version of the application. Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.
+The release version of the application. By default the `version` property in the `package.json` is used but it can be overridden with this argument. If neither are provided, the version of Electron will be used. Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.
 
 ##### `asar`
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function validateList (list, supported, name) {
 function getMetadata (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
-  if (!opts['app-version'] || !opts['build-version']) props.push('version')
+  if (!opts['app-version']) props.push('version')
   if (!opts.version) props.push(['dependencies.electron', 'devDependencies.electron'])
 
   // Name and version provided, no need to infer
@@ -80,8 +80,8 @@ function inferNameAndVersionFromInstalled (packageName, opts, result, cb) {
   }
 
   if (result.values.version) {
-    debug('Inferring packageVersion from version in package.json')
-    opts.packageVersion = result.values.version
+    debug('Inferring app-version from version in package.json')
+    opts['app-version'] = result.values.version
   }
 
   if (result.values[`dependencies.${packageName}`]) {

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ function validateList (list, supported, name) {
 function getMetadata (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
-  if (!opts.version) props.push(['dependencies.electron', 'devDependencies.electron'])
   if (!opts['app-version'] || !opts['build-version']) props.push('version')
+  if (!opts.version) props.push(['dependencies.electron', 'devDependencies.electron'])
 
   // Name and version provided, no need to infer
   if (props.length === 0) return cb(null)

--- a/index.js
+++ b/index.js
@@ -48,10 +48,11 @@ function validateList (list, supported, name) {
   return list
 }
 
-function getNameAndVersion (opts, dir, cb) {
+function getMetadata (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
   if (!opts.version) props.push(['dependencies.electron', 'devDependencies.electron'])
+  if (!opts['app-version'] || !opts['build-version']) props.push('version')
 
   // Name and version provided, no need to infer
   if (props.length === 0) return cb(null)
@@ -77,6 +78,12 @@ function inferNameAndVersionFromInstalled (packageName, opts, result, cb) {
     debug('Inferring application name from productName or name in package.json')
     opts.name = result.values.productName
   }
+
+  if (result.values.version) {
+    debug('Inferring packageVersion from version in package.json')
+    opts.packageVersion = result.values.version
+  }
+
   if (result.values[`dependencies.${packageName}`]) {
     resolve(packageName, {
       basedir: path.dirname(result.source[`dependencies.${packageName}`].src)
@@ -223,7 +230,7 @@ module.exports = function packager (opts, cb) {
   debug(`Target Platforms: ${platforms.join(', ')}`)
   debug(`Target Architectures: ${archs.join(', ')}`)
 
-  getNameAndVersion(opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {
+  getMetadata(opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {
     if (err) {
       err.message = 'Unable to determine application name or Electron version. ' +
         'Please specify an application name and Electron version.\n\n' +

--- a/mac.js
+++ b/mac.js
@@ -30,7 +30,7 @@ class MacApp {
   }
 
   get appVersion () {
-    return this.opts['app-version'] || this.opts.packageVersion
+    return this.opts['app-version']
   }
 
   get buildVersion () {

--- a/mac.js
+++ b/mac.js
@@ -30,7 +30,7 @@ class MacApp {
   }
 
   get appVersion () {
-    return this.opts['app-version']
+    return this.opts['app-version'] || this.opts.packageVersion
   }
 
   get buildVersion () {

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -24,6 +24,6 @@ case "$TRAVIS_OS_NAME" in
       -in codesign.csr -out codesign.cer
     openssl pkcs12 -export -in codesign.cer -inkey codesign.key -out codesign.p12 -password pass:12345
     security import codesign.p12 -k ~/Library/Keychains/login.keychain -P 12345 -T /usr/bin/codesign
-    npm install wine-darwin@1.9.16
+    npm install wine-darwin@1.9.17-0
     ;;
 esac

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -26,6 +26,6 @@ case "$TRAVIS_OS_NAME" in
     security import codesign.p12 -k ~/Library/Keychains/login.keychain -P 12345 -T /usr/bin/codesign
     npm install wine-darwin@1.9.17-1
     # Setup ~/.wine by running a command
-    wine hostname
+    ./node_modules/.bin/wine hostname
     ;;
 esac

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -24,6 +24,6 @@ case "$TRAVIS_OS_NAME" in
       -in codesign.csr -out codesign.cer
     openssl pkcs12 -export -in codesign.cer -inkey codesign.key -out codesign.p12 -password pass:12345
     security import codesign.p12 -k ~/Library/Keychains/login.keychain -P 12345 -T /usr/bin/codesign
-    brew install wine
+    npm install wine-darwin@1.9.16
     ;;
 esac

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -24,6 +24,8 @@ case "$TRAVIS_OS_NAME" in
       -in codesign.csr -out codesign.cer
     openssl pkcs12 -export -in codesign.cer -inkey codesign.key -out codesign.p12 -password pass:12345
     security import codesign.p12 -k ~/Library/Keychains/login.keychain -P 12345 -T /usr/bin/codesign
-    npm install wine-darwin@1.9.17-0
+    npm install wine-darwin@1.9.17-1
+    # Setup ~/.wine by running a command
+    wine hostname
     ;;
 esac

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -24,5 +24,6 @@ case "$TRAVIS_OS_NAME" in
       -in codesign.csr -out codesign.cer
     openssl pkcs12 -export -in codesign.cer -inkey codesign.key -out codesign.p12 -password pass:12345
     security import codesign.p12 -k ~/Library/Keychains/login.keychain -P 12345 -T /usr/bin/codesign
+    brew install wine
     ;;
 esac

--- a/test/fixtures/basic/package.json
+++ b/test/fixtures/basic/package.json
@@ -1,5 +1,6 @@
 {
   "main": "main.js",
+  "version": "4.99.101",
   "productName": "MainJS",
   "dependencies": {
     "run-series": "^1.1.1"


### PR DESCRIPTION
This infers the `--app-version` from the `package.json` `version` property if it has not been passed in through the command line.

For an app using Electron `1.2.6` with a `package.json` version of `1.1.0`:

Before | After
--- | ---
![screen shot 2016-08-11 at 4 08 52 pm](https://cloud.githubusercontent.com/assets/2289/17608156/53578ed6-5fdf-11e6-9e35-7574306ede48.png) | ![screen shot 2016-08-11 at 4 17 56 pm](https://cloud.githubusercontent.com/assets/2289/17608155/535472d2-5fdf-11e6-8b69-b920e8a49fb7.png)

cc pairing with @kevinsawicki @jlord 

Fixes #306 
