### PR TITLE
Add protocol/protocol-name docs and test

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -292,10 +292,10 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 
 *Array* of *String*s
 
-The URL protocol scheme(s) to associate the app with. Specifying `myapp` would
-cause URLs such as `myapp://path` to be opened with the app. Maps to the
-`CFBundleURLSchemes` metadata property. This option requires a corresponding
-`protocol-name` option to be specified.
+The URL protocol scheme(s) to associate the app with. For example, specifying
+`myapp` would cause URLs such as `myapp://path` to be opened with the app. Maps
+to the `CFBundleURLSchemes` metadata property. This option requires a
+corresponding `protocol-name` option to be specified.
 
 ##### `protocol-name`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -290,20 +290,20 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 
 ##### `protocol`
 
-*String*
+*Array* of *String*s
 
 The URL protocol scheme to associate the app with. Specifying `myapp` would
 cause URLs such as `myapp://path` to be opened with the app. This option can be
 specified multiple times to register multiple protocol schemes with the app.
-Maps to the `CFBundleURLSchemes` metadata property. This argument requires
-a corresponding `--protocol-name` argument.
+Maps to the `CFBundleURLSchemes` metadata property. This option requires
+a corresponding `protocol-name` option to be specified.
 
 ##### `protocol-name`
 
-*String*
+*Array* of *String*s
 
 The descriptive name of the URL protocol scheme specified as the `protocol`
-argument. Maps to the `CFBundleURLName` metadata property.
+option. Maps to the `CFBundleURLName` metadata property.
 
 #### Windows targets only
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -292,17 +292,16 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 
 *Array* of *String*s
 
-The URL protocol scheme to associate the app with. Specifying `myapp` would
-cause URLs such as `myapp://path` to be opened with the app. This option can be
-specified multiple times to register multiple protocol schemes with the app.
-Maps to the `CFBundleURLSchemes` metadata property. This option requires
-a corresponding `protocol-name` option to be specified.
+The URL protocol scheme(s) to associate the app with. Specifying `myapp` would
+cause URLs such as `myapp://path` to be opened with the app. Maps to the
+`CFBundleURLSchemes` metadata property. This option requires a corresponding
+`protocol-name` option to be specified.
 
 ##### `protocol-name`
 
 *Array* of *String*s
 
-The descriptive name of the URL protocol scheme specified as the `protocol`
+The descriptive name(s) of the URL protocol scheme(s) specified via the `protocol`
 option. Maps to the `CFBundleURLName` metadata property.
 
 #### Windows targets only

--- a/docs/api.md
+++ b/docs/api.md
@@ -288,6 +288,21 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 - `entitlements` (*String*): The path to the 'parent' entitlements.
 - `entitlements-inherit` (*String*): The path to the 'child' entitlements.
 
+##### `protocol`
+
+*String*
+
+The URL protocol scheme to associate the app with. Specifying `myapp` would
+cause URLs such as `myapp://path` to be opened with the app. This option can be
+specified multiple times to register multiple protocol schemes with the app.
+
+##### `protocol-name`
+
+*String*
+
+The descriptive name of the URL protocol scheme specified as the `protocol`
+argument.
+
 #### Windows targets only
 
 ##### `version-string`

--- a/docs/api.md
+++ b/docs/api.md
@@ -295,7 +295,8 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 The URL protocol scheme to associate the app with. Specifying `myapp` would
 cause URLs such as `myapp://path` to be opened with the app. This option can be
 specified multiple times to register multiple protocol schemes with the app.
-Maps to the `CFBundleURLSchemes` metadata property.
+Maps to the `CFBundleURLSchemes` metadata property. This argument requires
+a corresponding `--protocol-name` argument.
 
 ##### `protocol-name`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -295,13 +295,14 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 The URL protocol scheme to associate the app with. Specifying `myapp` would
 cause URLs such as `myapp://path` to be opened with the app. This option can be
 specified multiple times to register multiple protocol schemes with the app.
+Maps to the `CFBundleURLSchemes` metadata property.
 
 ##### `protocol-name`
 
 *String*
 
 The descriptive name of the URL protocol scheme specified as the `protocol`
-argument.
+argument. Maps to the `CFBundleURLName` metadata property.
 
 #### Windows targets only
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -58,3 +58,21 @@ test('CLI argument test: --out without a value is the same as not passing --out'
   t.equal(args.out, null)
   t.end()
 })
+
+test('CLI argument test: --protocol with a corresponding --protocol-name', (t) => {
+  var args = common.parseCLIArgs(['--protocol=foo', '--protocol-name=Foo'])
+  t.deepEqual(args.protocols, [{schemes: ['foo'], name: 'Foo'}])
+  t.end()
+})
+
+test('CLI argument test: --protocol without a corresponding --protocol-name', (t) => {
+  var args = common.parseCLIArgs(['--protocol=foo'])
+  t.deepEqual(args.protocols, undefined)
+  t.end()
+})
+
+test('CLI argument test: multiple --protocol/--protocol-name argument pairs', (t) => {
+  var args = common.parseCLIArgs(['--protocol=foo', '--protocol-name=Foo', '--protocol=bar', '--protocol-name=Bar'])
+  t.deepEqual(args.protocols, [{schemes: ['foo'], name: 'Foo'}, {schemes: ['bar'], name: 'Bar'}])
+  t.end()
+})

--- a/usage.txt
+++ b/usage.txt
@@ -85,6 +85,11 @@ osx-sign           (OSX host platform only) Whether to sign the OSX app packages
                    - identity: should contain the identity to be used when running `codesign`
                    - entitlements: the path to entitlements used in signing
                    - entitlements-inherit: the path to the 'child' entitlements
+protocol           URL protocol scheme to register the app as an opener of.
+                   For example, `--protocol=myapp` would register the app to open
+                   URLs such as `myapp://path`. This argument requires a `--protocol-name`
+                   argument to also be specified.
+protocol-name      Descriptive name of URL protocol scheme specified via `--protocol`
 
 * win32 target platform only *
 


### PR DESCRIPTION
Adds documentation and an initial test for the `protocol`/`protocol-name` option.

Closes #121