### PR TITLE
Remove log statement at start of test infer electron test

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -237,7 +237,6 @@ function createInferElectronPrebuiltTest (opts) {
 
 function createInferElectronTest (opts) {
   return function (t) {
-    console.error('start createInferElectronTest')
     t.timeoutAfter(config.timeout)
 
     // Don't specify name or version


### PR DESCRIPTION
This seemed unneeded since the spec name is already logged by tape.

```
  setup
  infer test using `electron` package
start createInferElectronTest
```

/cc @zeke 