### PR TITLE
Handle errors setting up tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,12 @@ function npmInstallforFixtures () {
 
 let setupFuncs = preDownloadElectron().concat(npmInstallforFixtures())
 
-series(setupFuncs, () => {
+series(setupFuncs, (error) => {
+  if (error) {
+    console.error(error.stack || error)
+    return process.exit(1)
+  }
+
   console.log('Running tests...')
   require('./basic')
   require('./asar')

--- a/test/index.js
+++ b/test/index.js
@@ -31,7 +31,7 @@ function npmInstallforFixtures () {
   return fixtures.map((fixture) => {
     return (cb) => {
       console.log(`Running npm install in fixtures/${fixture}...`)
-      exec('npm install', {cwd: util.fixtureSubdir(fixture)}, cb)
+      exec('npm install --no-bin-links', {cwd: util.fixtureSubdir(fixture)}, cb)
     }
   })
 }


### PR DESCRIPTION
Previously, if `npm install` on the fixtures failed or if Electron download failed, the tests would not fail.

This pull request adds error handling when either of those fails.