### PR TITLE
Enforce minimum Node version in CLI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* [CLI] Minimum Node version is enforced
+* [CLI] Minimum Node version is enforced (#454)
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+* [CLI] Minimum Node version is enforced
+
 ### Fixed
 
 * [CLI] ensure --out has either a string or null value (#442)

--- a/cli.js
+++ b/cli.js
@@ -2,11 +2,19 @@
 
 'use strict'
 
-const common = require('./common')
-const fs = require('fs')
-const packager = require('./')
-const path = require('path')
-const usage = fs.readFileSync(path.join(__dirname, 'usage.txt')).toString()
+var nodeVersionInfo = process.versions.node.split('.').map(function (n) { return Number(n) })
+if (nodeVersionInfo < [4, 0, 0]) {
+  console.error('CANNOT RUN WITH NODE ' + process.versions.node)
+  console.error('Electron Packager requires Node 4.0 or above.')
+  process.exit(1)
+}
+
+// Not consts so that this file can load in Node < 4.0
+var common = require('./common')
+var fs = require('fs')
+var packager = require('./')
+var path = require('path')
+var usage = fs.readFileSync(path.join(__dirname, 'usage.txt')).toString()
 
 var args = common.parseCLIArgs(process.argv.slice(2))
 


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

If Electron Packager's CLI is run with an old version of Node, it will give a SyntaxError which is not intuitive to people what that means. This change (based on a suggestion by @MarshallOfSound in https://github.com/electron-userland/electron-packager/pull/445#issuecomment-239189295) gets rid of the SyntaxError, but tells the user exactly why the CLI will not run, before exiting with a non-zero status code. (Example output below.)

**Are your changes appropriately documented?**

Yes (prior to this PR existing):

* [the NEWS file](https://github.com/electron-userland/electron-packager/blob/v7.0.0/NEWS.md#700---2016-04-17)
* [the installation instructions](https://github.com/electron-userland/electron-packager#installation)
* the [`engines` section of `package.json`](https://github.com/electron-userland/electron-packager/blob/v7.0.0/package.json#L42-L44)

**Do your changes have sufficient test coverage?**

No, but it's dependent on Node version, so I felt it wasn't worth doing extra work just to get code coverage for this feature. I tested manually with these instructions on Linux:

1. Install nodeenv
2. Run `nodeenv -n 0.12.15 --prebuilt /tmp/n012`
3. Run `source /tmp/n012/bin/activate`
4. Run `cd /path/to/electron-packager && ./cli.js`

Expected output:

```
CANNOT RUN WITH NODE 0.12.15
Electron Packager requires Node 4.0 or above.
```

**Does the testsuite pass successfully on your local machine?**

Yes