### PR TITLE
Remove special path characters from app name in filenames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 * Allow scoped package names as Electron app names - invalid characters are replaced with
-  hyphens (#308)
+  hyphens (#308, #455)
 
 ### Deprecated
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
 
 * `win32metadata` option (#331, #463)
 
+### Fixed
+
+* Allow scoped package names as Electron app names - invalid characters are replaced with
+  hyphens (#308)
+
 ### Deprecated
 
 * `version-string` is deprecated in favor of `win32metadata` (#331, #463)

--- a/common.js
+++ b/common.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra')
 const minimist = require('minimist')
 const os = require('os')
 const path = require('path')
+const sanitize = require('sanitize-filename')
 const series = require('run-series')
 
 const archs = ['ia32', 'x64']
@@ -78,8 +79,12 @@ function asarApp (appPath, asarOptions, cb) {
   })
 }
 
+function sanitizeAppName (name) {
+  return sanitize(name, {replacement: '-'})
+}
+
 function generateFinalBasename (opts) {
-  return `${opts.name}-${opts.platform}-${opts.arch}`
+  return `${sanitizeAppName(opts.name)}-${opts.platform}-${opts.arch}`
 }
 
 function generateFinalPath (opts) {
@@ -292,5 +297,6 @@ module.exports = {
 
   rename: function rename (basePath, oldName, newName, cb) {
     fs.rename(path.join(basePath, oldName), path.join(basePath, newName), cb)
-  }
+  },
+  sanitizeAppName: sanitizeAppName
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,6 +175,9 @@ default ignored directories listed above.*
 
 The application name. If omitted, it will use the `productName` or `name` value from the nearest `package.json`.
 
+**Regardless of source, characters in the Electron app name which are not allowed in all target
+platforms (e.g., `/`), will be replaced by hyphens (`-`).**
+
 ##### `out`
 
 *String* (default: current working directory)

--- a/docs/api.md
+++ b/docs/api.md
@@ -176,7 +176,7 @@ default ignored directories listed above.*
 The application name. If omitted, it will use the `productName` or `name` value from the nearest `package.json`.
 
 **Regardless of source, characters in the Electron app name which are not allowed in all target
-platforms (e.g., `/`), will be replaced by hyphens (`-`).**
+platforms' filenames (e.g., `/`), will be replaced by hyphens (`-`).**
 
 ##### `out`
 

--- a/linux.js
+++ b/linux.js
@@ -7,7 +7,7 @@ module.exports = {
   createApp: function createApp (opts, templatePath, callback) {
     common.initializeApp(opts, templatePath, path.join('resources', 'app'), function buildLinuxApp (err, tempPath) {
       if (err) return callback(err)
-      common.rename(tempPath, 'electron', opts.name, function (err) {
+      common.rename(tempPath, 'electron', common.sanitizeAppName(opts.name), function (err) {
         if (err) return callback(err)
         common.moveApp(opts, tempPath, callback)
       })

--- a/mac.js
+++ b/mac.js
@@ -12,7 +12,7 @@ class MacApp {
   constructor (opts, stagingPath) {
     this.opts = opts
     this.stagingPath = stagingPath
-    this.appName = opts.name
+    this.appName = common.sanitizeAppName(opts.name)
     this.operations = []
     this.renamedAppPath = path.join(this.stagingPath, `${this.appName}.app`)
     this.electronAppPath = path.join(this.stagingPath, 'Electron.app')

--- a/mac.js
+++ b/mac.js
@@ -12,9 +12,9 @@ class MacApp {
   constructor (opts, stagingPath) {
     this.opts = opts
     this.stagingPath = stagingPath
-    this.appName = common.sanitizeAppName(opts.name)
+    this.appName = opts.name
     this.operations = []
-    this.renamedAppPath = path.join(this.stagingPath, `${this.appName}.app`)
+    this.renamedAppPath = path.join(this.stagingPath, `${common.sanitizeAppName(this.appName)}.app`)
     this.electronAppPath = path.join(this.stagingPath, 'Electron.app')
     this.contentsPath = path.join(this.electronAppPath, 'Contents')
     this.frameworksPath = path.join(this.contentsPath, 'Frameworks')
@@ -49,9 +49,9 @@ class MacApp {
   updatePlist (base, displayName, identifier, name) {
     return Object.assign(base, {
       CFBundleDisplayName: displayName,
-      CFBundleExecutable: displayName,
+      CFBundleExecutable: common.sanitizeAppName(displayName),
       CFBundleIdentifier: identifier,
-      CFBundleName: name
+      CFBundleName: common.sanitizeAppName(name)
     })
   }
 
@@ -92,7 +92,7 @@ class MacApp {
     let helperEHPlist = this.loadPlist(helperEHPlistFilename)
     let helperNPPlist = this.loadPlist(helperNPPlistFilename)
 
-    let defaultBundleName = `com.electron.${this.appName.toLowerCase()}`
+    let defaultBundleName = `com.electron.${common.sanitizeAppName(this.appName).toLowerCase()}`
 
     let appBundleIdentifier = filterCFBundleIdentifier(this.opts['app-bundle-id'] || defaultBundleName)
     this.helperBundleIdentifier = filterCFBundleIdentifier(this.opts['helper-bundle-id'] || `${appBundleIdentifier}.helper`)
@@ -137,9 +137,9 @@ class MacApp {
       return (cb) => {
         let executableBasePath = path.join(this.frameworksPath, `Electron${suffix}.app`, 'Contents', 'MacOS')
 
-        common.rename(executableBasePath, `Electron${suffix}`, `${this.appName}${suffix}`, (err) => {
+        common.rename(executableBasePath, `Electron${suffix}`, `${common.sanitizeAppName(this.appName)}${suffix}`, (err) => {
           if (err) return cb(err)
-          common.rename(this.frameworksPath, `Electron${suffix}.app`, `${this.appName}${suffix}.app`, cb)
+          common.rename(this.frameworksPath, `Electron${suffix}.app`, `${common.sanitizeAppName(this.appName)}${suffix}.app`, cb)
         })
       }
     }), (err) => {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "plist": "^1.1.0",
     "rcedit": "^0.5.1",
     "resolve": "^1.1.6",
-    "run-series": "^1.1.1"
+    "run-series": "^1.1.1",
+    "sanitize-filename": "^1.6.0"
   },
   "devDependencies": {
     "buffer-equal": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,9 @@ detailed descriptions, see the [API documentation](https://github.com/electron-u
 
 If `appname` is omitted, this will use the name specified by "productName" or "name" in the nearest package.json.
 
+**Characters in the Electron app name which are not allowed in all target platforms (e.g., `/`),
+will be replaced by hyphens (`-`).**
+
 You should be able to launch the app on the platform you built for. If not, check your settings and try again.
 
 **Be careful** not to include `node_modules` you don't want into your final app. If you put them in

--- a/readme.md
+++ b/readme.md
@@ -78,8 +78,8 @@ detailed descriptions, see the [API documentation](https://github.com/electron-u
 
 If `appname` is omitted, this will use the name specified by "productName" or "name" in the nearest package.json.
 
-**Characters in the Electron app name which are not allowed in all target platforms (e.g., `/`),
-will be replaced by hyphens (`-`).**
+**Characters in the Electron app name which are not allowed in all target platforms' filenames
+(e.g., `/`), will be replaced by hyphens (`-`).**
 
 You should be able to launch the app on the platform you built for. If not, check your settings and try again.
 

--- a/test/mac.js
+++ b/test/mac.js
@@ -33,23 +33,23 @@ function createHelperAppPathsTest (baseOpts, expectedName) {
         frameworksPath = path.join(paths[0], `${expectedName}.app`, 'Contents', 'Frameworks')
         // main Helper.app is already tested in basic test suite; test its executable and the other helpers
         fs.stat(path.join(frameworksPath, getHelperExecutablePath(`${expectedName} Helper`)), cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isFile(), 'The Helper.app executable should reflect sanitized opts.name')
         fs.stat(path.join(frameworksPath, `${expectedName} Helper EH.app`), cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isDirectory(), 'The Helper EH.app should reflect sanitized opts.name')
         fs.stat(path.join(frameworksPath, getHelperExecutablePath(`${expectedName} Helper EH`)), cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isFile(), 'The Helper EH.app executable should reflect sanitized opts.name')
         fs.stat(path.join(frameworksPath, `${expectedName} Helper NP.app`), cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isDirectory(), 'The Helper NP.app should reflect sanitized opts.name')
         fs.stat(path.join(frameworksPath, getHelperExecutablePath(`${expectedName} Helper NP`)), cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isFile(), 'The Helper NP.app executable should reflect sanitized opts.name')
         cb()
       }
-    ], function (err) {
+    ], (err) => {
       t.end(err)
     })
   }
@@ -207,16 +207,16 @@ function createBinaryNameTest (baseOpts, expectedAppName) {
     let appName = expectedAppName || opts.name
 
     waterfall([
-      function (cb) {
+      (cb) => {
         packager(opts, cb)
-      }, function (paths, cb) {
+      }, (paths, cb) => {
         binaryPath = path.join(paths[0], `${appName}.app`, 'Contents', 'MacOS')
         fs.stat(path.join(binaryPath, appName), cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isFile(), 'The binary should reflect a sanitized opts.name')
         cb()
       }
-    ], function (err) {
+    ], (err) => {
       t.end(err)
     })
   }

--- a/test/win32.js
+++ b/test/win32.js
@@ -135,6 +135,27 @@ test('error message unchanged when error not about wine', (t) => {
 })
 
 util.setup()
+test('win32 executable name is based on sanitized app name', (t) => {
+  let opts = Object.assign({}, baseOpts, {name: '@username/package-name'})
+
+  waterfall([
+    (cb) => {
+      packager(opts, cb)
+    }, (paths, cb) => {
+      t.equal(1, paths.length, '1 bundle created')
+      let appExePath = path.join(paths[0], '@username-package-name.exe')
+      fs.stat(appExePath, cb)
+    }, (stats, cb) => {
+      t.true(stats.isFile(), 'The sanitized EXE filename should exist')
+      cb()
+    }
+  ], (err) => {
+    t.end(err)
+  })
+})
+util.teardown()
+
+util.setup()
 test('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
 util.teardown()
 

--- a/win32.js
+++ b/win32.js
@@ -22,7 +22,7 @@ module.exports = {
     common.initializeApp(opts, templatePath, path.join('resources', 'app'), function buildWinApp (err, tempPath) {
       if (err) return callback(err)
 
-      let newExeName = `${opts.name}.exe`
+      let newExeName = `${common.sanitizeAppName(opts.name)}.exe`
       var operations = [
         function (cb) {
           common.rename(tempPath, 'electron.exe', newExeName, cb)


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

This fixes the problem where an Electron app name contains characters that are invalid in some target platform's filename. The most common case is [Node's scoped packages](https://docs.npmjs.com/misc/scope). The change utilizes the [`sanitize-filename`](https://www.npmjs.com/package/sanitize-filename) module to do all of the filename filtering.

Fixes #308.

**Are your changes appropriately documented?**

I added notes to both `readme.md` and `docs/api.md` saying that invalid characters will be replaced with a hyphen.

**Do your changes have sufficient test coverage?**

I added tests to make sure that binary names for all target platforms are sanitized properly. The OSX test also tests that the `.app` folder name is sanitized appropriately.

**Does the testsuite pass successfully on your local machine?**

Yes