### PR TITLE
Disallow setting osx-sign.binaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 * The `package.json` `version` property is the default app version if `--app-version` is unspecified (#449)
 
+### Changed
+
+* [darwin/mas] Explicitly disallow `osx-sign.binaries` (#459)
+
 ## [7.6.0] - 2016-08-14
 
 ### Added

--- a/mac.js
+++ b/mac.js
@@ -238,8 +238,8 @@ function createSignOpts (properties, platform, app) {
   common.subOptionWarning(signOpts, 'osx-sign', 'app', app)
 
   if (signOpts.binaries) {
-    console.warn('WARNING: osx-sign.binaries signing will fail. Sign manually, ' +
-                 'or with electron-osx-sign.')
+    console.warn('WARNING: osx-sign.binaries is not an allowed sub-option. Not passing to electron-osx-sign.')
+    delete signOpts.binaries
   }
 
   // Take argument osx-sign as signing identity:

--- a/test/mac.js
+++ b/test/mac.js
@@ -572,6 +572,13 @@ module.exports = function (baseOpts) {
     t.end()
   })
 
+  test('osx-sign argument test: binaries not set', (t) => {
+    let args = {binaries: ['binary1', 'binary2']}
+    let signOpts = mac.createSignOpts(args, 'darwin', 'out')
+    t.same(signOpts, {app: 'out', platform: 'darwin'})
+    t.end()
+  })
+
   util.setup()
   test('codesign test', function (t) {
     t.timeoutAfter(config.macExecTimeout)


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

Removes the suboption `osx-sign.binaries` if it is set and print a warning to that effect. See discussion in #285 and #286 for context.

CC: @sethlu 

Closes #285.

**Are your changes appropriately documented?**

Not necessary, the docs specify which suboptions are supported.

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes