### PR TITLE
Remove deprecated options for asar & electron-download

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Removed
+
+* `asar-unpack` is removed in favor of `asar.unpack`
+* `asar-unpack-dir` is removed in favor of `asar.unpackDir`
+* `cache` is removed in favor of `download.cache`
+* `strict-ssl` is removed in favor of `download.strictSSL`
+
 ## [7.7.0] - 2016-08-20
 
 ### Added

--- a/common.js
+++ b/common.js
@@ -19,13 +19,11 @@ function parseCLIArgs (argv) {
       'deref-symlinks',
       'download.strictSSL',
       'overwrite',
-      'prune',
-      'strict-ssl'
+      'prune'
     ],
     default: {
       'deref-symlinks': true,
-      'download.strictSSL': true,
-      'strict-ssl': true
+      'download.strictSSL': true
     },
     string: [
       'out'
@@ -95,15 +93,6 @@ function subOptionWarning (properties, optionName, parameter, value) {
   properties[parameter] = value
 }
 
-function deprecatedParameter (properties, oldName, newName, extraCondition/* optional */) {
-  if (extraCondition === undefined) {
-    extraCondition = true
-  }
-  if (properties.hasOwnProperty(oldName) && extraCondition) {
-    console.warn(`The ${oldName} parameter is deprecated, use ${newName} instead`)
-  }
-}
-
 function userIgnoreFilter (opts) {
   var ignore = opts.ignore || []
   var ignoreFunc = null
@@ -153,9 +142,6 @@ function userIgnoreFilter (opts) {
 }
 
 function createAsarOpts (opts) {
-  deprecatedParameter(opts, 'asar-unpack', 'asar.unpack')
-  deprecatedParameter(opts, 'asar-unpack-dir', 'asar.unpackDir')
-
   let asarOptions
   if (opts.asar === true) {
     asarOptions = {}
@@ -168,10 +154,7 @@ function createAsarOpts (opts) {
     return false
   }
 
-  return Object.assign({
-    unpack: opts['asar-unpack'],
-    unpackDir: opts['asar-unpack-dir']
-  }, asarOptions)
+  return asarOptions
 }
 
 module.exports = {
@@ -189,13 +172,7 @@ module.exports = {
   createAsarOpts: createAsarOpts,
 
   createDownloadOpts: function createDownloadOpts (opts, platform, arch) {
-    deprecatedParameter(opts, 'cache', 'download.cache')
-    deprecatedParameter(opts, 'strict-ssl', 'download.strictSSL', opts['strict-ssl'] === false)
-
-    var downloadOpts = Object.assign({
-      cache: opts.cache,
-      strictSSL: opts['strict-ssl']
-    }, opts.download)
+    let downloadOpts = opts.download || {}
 
     subOptionWarning(downloadOpts, 'download', 'platform', platform)
     subOptionWarning(downloadOpts, 'download', 'arch', arch)

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,39 +103,11 @@ Whether to package the application's source code into an archive, using [Electro
   - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/**'` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
   - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*'` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
 
-##### `asar-unpack`
-
-*String* (**deprecated** and will be removed in a future major version,
-please use the [`asar.unpack`](#asar) parameter instead)
-
-A [glob expression](https://github.com/isaacs/minimatch#features), when specified, unpacks the file with matching names to the `app.asar.unpacked` directory.
-
-##### `asar-unpack-dir`
-
-*String* (**deprecated** and will be removed in a future major version,
-please use the [`asar.unpackDir`](#asar) parameter instead)
-
-Unpacks the dir to `app.asar.unpacked` directory whose names exactly or pattern match this string. The `asar-unpack-dir` is relative to `dir`.
-
-Some examples:
-
-- `asar-unpack-dir=sub_dir` will unpack the directory `/<dir>/sub_dir`
-- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`, but it will note include their subdirectories.
-- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
-- `asar-unpack-dir=**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
-
 ##### `build-version`
 
 *String*
 
 The build version of the application. Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on OS X.
-
-##### `cache`
-
-*String* (default: `$HOME/.electron`) (**deprecated** and will be removed in a future major version,
-please use the [`download.cache`](#download) parameter instead)
-
-The directory where prebuilt, pre-packaged Electron downloads are cached.
 
 ##### `derefSymlinks`
 
@@ -220,13 +192,6 @@ Whether to replace an already existing output directory for a given platform (`t
 *Boolean*
 
 Runs [`npm prune --production`](https://docs.npmjs.com/cli/prune) before starting to package the app.
-
-##### `strict-ssl`
-
-*Boolean* (**default: `true`**) (**deprecated** and will be removed in a future major version,
-please use the [`download.strictSSL`](#download) parameter instead)
-
-Whether SSL certificates are required to be valid when downloading Electron.
 
 ##### `tmpdir`
 

--- a/test/asar.js
+++ b/test/asar.js
@@ -94,7 +94,7 @@ test('asar argument test: asar is true', function (t) {
   }
 
   var asarOpts = common.createAsarOpts(opts)
-  t.same(asarOpts, {unpack: undefined, unpackDir: undefined})
+  t.same(asarOpts, {})
   t.end()
 })
 
@@ -105,54 +105,6 @@ test('asar argument test: asar is not an Object or a bool', function (t) {
 
   var asarOpts = common.createAsarOpts(opts)
   t.false(asarOpts, 'createAsarOpts returns false')
-  t.end()
-})
-
-test('asar argument test: asar-unpack still works albeit deprecated', function (t) {
-  var opts = {
-    asar: true,
-    'asar-unpack': 'deprecated'
-  }
-
-  var asarOpts = common.createAsarOpts(opts)
-  t.same(asarOpts, {unpack: 'deprecated', unpackDir: undefined})
-  t.end()
-})
-
-test('asar argument test: asar.unpack overwrites asar-unpack', function (t) {
-  var opts = {
-    asar: {
-      unpack: 'should exist'
-    },
-    'asar-unpack': 'should not exist'
-  }
-
-  var asarOpts = common.createAsarOpts(opts)
-  t.same(asarOpts, {unpack: 'should exist', unpackDir: undefined})
-  t.end()
-})
-
-test('asar argument test: asar-unpack-dir still works albeit deprecated', function (t) {
-  var opts = {
-    asar: true,
-    'asar-unpack-dir': 'deprecated'
-  }
-
-  var asarOpts = common.createAsarOpts(opts)
-  t.same(asarOpts, {unpack: undefined, unpackDir: 'deprecated'})
-  t.end()
-})
-
-test('asar argument test: asar.unpackDir overwrites asar-unpack-dir', function (t) {
-  var opts = {
-    asar: {
-      unpackDir: 'should exist'
-    },
-    'asar-unpack-dir': 'should not exist'
-  }
-
-  var asarOpts = common.createAsarOpts(opts)
-  t.same(asarOpts, {unpack: undefined, unpackDir: 'should exist'})
   t.end()
 })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -363,34 +363,6 @@ function createDisableSymlinkDereferencingTest (opts) {
   }
 }
 
-test('download argument test: download.cache overwrites cache', function (t) {
-  var opts = {
-    cache: 'should not exist',
-    download: {
-      cache: 'should exist'
-    },
-    version: '0.36.0'
-  }
-
-  var downloadOpts = common.createDownloadOpts(opts, 'linux', 'x64')
-  t.same(downloadOpts, {arch: 'x64', platform: 'linux', version: '0.36.0', cache: opts.download.cache, strictSSL: undefined})
-  t.end()
-})
-
-test('download argument test: download.strictSSL overwrites strict-ssl', function (t) {
-  var opts = {
-    download: {
-      strictSSL: false
-    },
-    'strict-ssl': true,
-    version: '0.36.0'
-  }
-
-  var downloadOpts = common.createDownloadOpts(opts, 'linux', 'x64')
-  t.same(downloadOpts, {arch: 'x64', platform: 'linux', version: '0.36.0', cache: undefined, strictSSL: opts.download.strictSSL})
-  t.end()
-})
-
 test('download argument test: download.{arch,platform,version} does not overwrite {arch,platform,version}', function (t) {
   var opts = {
     download: {
@@ -402,7 +374,7 @@ test('download argument test: download.{arch,platform,version} does not overwrit
   }
 
   var downloadOpts = common.createDownloadOpts(opts, 'linux', 'x64')
-  t.same(downloadOpts, {arch: 'x64', platform: 'linux', version: '0.36.0', cache: undefined, strictSSL: undefined})
+  t.same(downloadOpts, {arch: 'x64', platform: 'linux', version: '0.36.0'})
   t.end()
 })
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -3,12 +3,6 @@
 const common = require('../common')
 const test = require('tape')
 
-test('CLI argument test: --strict-ssl default', function (t) {
-  var args = common.parseCLIArgs([])
-  t.true(args['strict-ssl'], 'default for --strict-ssl is true')
-  t.end()
-})
-
 test('CLI argument test: --download.strictSSL default', function (t) {
   var args = common.parseCLIArgs([])
   t.true(args.download.strictSSL, 'default for --download.strictSSL is true')

--- a/usage.txt
+++ b/usage.txt
@@ -36,15 +36,7 @@ asar               whether to package the source code within your app into an ar
                      regex .match this string
                    - unpackDir: unpacks the dir to the app.asar.unpacked directory whose names glob
                      pattern or exactly match this string. It's relative to the <sourcedir>.
-asar-unpack        unpacks the files to the app.asar.unpacked directory whose filenames regex .match
-                   this string
-                   (Deprecated, use asar.unpack instead)
-asar-unpack-dir    unpacks the dir to the app.asar.unpacked directory whose names glob pattern or
-                   exactly match this string. It's relative to the <sourcedir>.
-                   (Deprecated, use asar.unpackDir instead)
 build-version      build version to set for the app
-cache              directory of cached Electron downloads. Defaults to `$HOME/.electron`
-                   (Deprecated, use --download.cache instead)
 deref-symlinks     whether symlinks should be dereferenced. Defaults to true.
 download           a list of sub-options to pass to electron-download. They are specified via dot
                    notation, e.g., --download.cache=/tmp/cache
@@ -61,9 +53,6 @@ out                the dir to put the app into at the end. defaults to current w
 overwrite          if output directory for a platform already exists, replaces it rather than
                    skipping it
 prune              runs `npm prune --production` on the app
-strict-ssl         whether SSL certificates are required to be valid when downloading Electron.
-                   It defaults to true, use --strict-ssl=false to disable checks.
-                   (Deprecated, use --download.strictSSL instead)
 tmpdir             temp directory. Defaults to system temp directory, use --tmpdir=false to disable
                    use of a temporary directory.
 version            the version of Electron that is being packaged, see


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

Removes:

* The `electron-download`-related options (`cache` and `strict-ssl`), deprecated in 7.0.0 (4/17)
* `asar-unpack` and `asar-unpack-dir` options, deprecated in 7.3.0 (7/10)

**Are your changes appropriately documented?**

Removed docs about deprecated options and added NEWS entries

**Do your changes have sufficient test coverage?**

Removed tests related to the deprecated options

**Does the testsuite pass successfully on your local machine?**

Yes