### PR TITLE
Rename version-string option to win32metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+* `win32metadata` option (#331, #463)
+
+### Deprecated
+
+* `version-string` is deprecated in favor of `win32metadata` (#331, #463)
+
 ### Removed
 
 * `asar-unpack` is removed in favor of `asar.unpack`

--- a/docs/api.md
+++ b/docs/api.md
@@ -273,6 +273,11 @@ option. Maps to the `CFBundleURLName` metadata property.
 
 ##### `version-string`
 
+*Object* (**deprecated** and will be removed in a future major version, please use the
+[`win32metadata`](#win32metadata) parameter instead)
+
+##### `win32metadata`
+
 *Object*
 
 Object (also known as a "hash") of application metadata to embed into the executable:

--- a/test/win32.js
+++ b/test/win32.js
@@ -19,35 +19,33 @@ const baseOpts = {
 }
 
 function generateVersionStringTest (metadataProperties, extraOpts, expectedValues, assertionMsgs) {
-  return function (t) {
+  return (t) => {
     t.timeoutAfter(process.platform === 'darwin' ? config.macExecTimeout : config.timeout)
 
-    var appExePath
-    var opts = Object.assign({}, baseOpts, extraOpts)
+    let appExePath
+    let opts = Object.assign({}, baseOpts, extraOpts)
 
     waterfall([
-      function (cb) {
+      (cb) => {
         packager(opts, cb)
-      }, function (paths, cb) {
+      }, (paths, cb) => {
         appExePath = path.join(paths[0], opts.name + '.exe')
         fs.stat(appExePath, cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isFile(), 'The expected EXE file should exist')
-        cb()
-      }, function (cb) {
         rcinfo(appExePath, cb)
-      }, function (info, cb) {
+      }, (info, cb) => {
         metadataProperties = [].concat(metadataProperties)
         expectedValues = [].concat(expectedValues)
         assertionMsgs = [].concat(assertionMsgs)
-        metadataProperties.forEach(function (property, i) {
+        metadataProperties.forEach((property, i) => {
           var value = expectedValues[i]
           var msg = assertionMsgs[i]
           t.equal(info[property], value, msg)
         })
         cb()
       }
-    ], function (err) {
+    ], (err) => {
       t.end(err)
     })
   }
@@ -92,7 +90,7 @@ function setCopyrightAndCompanyNameTest (appCopyright, companyName) {
                                     'Company name should match version-string value'])
 }
 
-test('better error message when wine is not found', function (t) {
+test('better error message when wine is not found', (t) => {
   let err = Error('spawn wine ENOENT')
   err.code = 'ENOENT'
   err.syscall = 'spawn wine'
@@ -104,7 +102,7 @@ test('better error message when wine is not found', function (t) {
   t.end()
 })
 
-test('error message unchanged when error not about wine', function (t) {
+test('error message unchanged when error not about wine', (t) => {
   let errNotEnoent = Error('unchanged')
   errNotEnoent.code = 'ESOMETHINGELSE'
   errNotEnoent.syscall = 'spawn wine'

--- a/test/win32.js
+++ b/test/win32.js
@@ -78,7 +78,7 @@ function setCopyrightTest (appCopyright) {
 function setCopyrightAndCompanyNameTest (appCopyright, companyName) {
   var opts = {
     'app-copyright': appCopyright,
-    'version-string': {
+    'win32metadata': {
       CompanyName: companyName
     }
   }
@@ -87,7 +87,19 @@ function setCopyrightAndCompanyNameTest (appCopyright, companyName) {
                                    opts,
                                    [appCopyright, companyName],
                                    ['Legal copyright should match app copyright',
-                                    'Company name should match version-string value'])
+                                    'Company name should match win32metadata value'])
+}
+
+function setCompanyNameTest (companyName, optName) {
+  let opts = {}
+  opts[optName] = {
+    CompanyName: companyName
+  }
+
+  return generateVersionStringTest('CompanyName',
+                                   opts,
+                                   companyName,
+                                   `Company name should match ${optName} value`)
 }
 
 test('better error message when wine is not found', (t) => {
@@ -136,4 +148,12 @@ util.teardown()
 
 util.setup()
 test('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
+util.teardown()
+
+util.setup()
+test('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))
+util.teardown()
+
+util.setup()
+test('win32 set CompanyName test (version-string)', setCompanyNameTest('MyCompany LLC', 'version-string'))
 util.teardown()

--- a/test/win32.js
+++ b/test/win32.js
@@ -122,20 +122,18 @@ test('error message unchanged when error not about wine', (t) => {
   t.end()
 })
 
-if (process.env['TRAVIS_OS_NAME'] !== 'osx') {
-  util.setup()
-  test('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
-  util.teardown()
+util.setup()
+test('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
+util.teardown()
 
-  util.setup()
-  test('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
-  util.teardown()
+util.setup()
+test('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
+util.teardown()
 
-  util.setup()
-  test('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
-  util.teardown()
+util.setup()
+test('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
+util.teardown()
 
-  util.setup()
-  test('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
-  util.teardown()
-}
+util.setup()
+test('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
+util.teardown()

--- a/usage.txt
+++ b/usage.txt
@@ -82,10 +82,11 @@ protocol-name      Descriptive name of URL protocol scheme specified via `--prot
 
 * win32 target platform only *
 
-version-string     a list of sub-properties used to set the application metadata embedded into
+version-string     an alias for win32metadata (deprecated)
+win32metadata      a list of sub-properties used to set the application metadata embedded into
                    the executable. They are specified via dot notation,
-                   e.g. --version-string.CompanyName="Company Inc."
-                   or --version-string.ProductName="Product"
+                   e.g. --win32metadata.CompanyName="Company Inc."
+                   or --win32metadata.ProductName="Product"
                    Properties supported:
                    - CompanyName
                    - FileDescription

--- a/win32.js
+++ b/win32.js
@@ -9,7 +9,7 @@ function updateWineMissingException (err) {
   if (err && err.code === 'ENOENT' && err.syscall === 'spawn wine') {
     err.message = 'Could not find "wine" on your system.\n\n' +
       'Wine is required to use the app-copyright, app-version, build-version, icon, and \n' +
-      'version-string parameters for Windows targets.\n\n' +
+      'win32metadata parameters for Windows targets.\n\n' +
       'Make sure that the "wine" executable is in your PATH.\n\n' +
       'See https://github.com/electron-userland/electron-packager#building-windows-apps-from-non-windows-platforms for details.'
   }
@@ -29,7 +29,9 @@ module.exports = {
         }
       ]
 
-      var rcOpts = {'version-string': opts['version-string'] || {}}
+      let win32metadata = Object.assign({}, opts['version-string'], opts.win32metadata)
+
+      var rcOpts = {'version-string': win32metadata}
 
       if (opts['build-version']) {
         rcOpts['file-version'] = opts['build-version']
@@ -43,7 +45,7 @@ module.exports = {
         rcOpts['version-string'].LegalCopyright = opts['app-copyright']
       }
 
-      if (opts.icon || opts['version-string'] || opts['app-copyright'] || opts['app-version'] || opts['build-version']) {
+      if (opts.icon || opts.win32metadata || opts['version-string'] || opts['app-copyright'] || opts['app-version'] || opts['build-version']) {
         operations.push(function (cb) {
           common.normalizeExt(opts.icon, '.ico', function (err, icon) {
             // Icon might be omitted or only exist in one OS's format, so skip it if normalizeExt reports an error


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

Deprecates `version-string` in favor of `win32metadata`. `version-string` will be removed in a future major version.

Fixes #331.

**Are your changes appropriately documented?**

Updated NEWS, API, & CLI docs.

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes