### PR TITLE
Upgrade rcedit and asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
-    "asar": "^0.12.0",
+    "asar": "^0.12.2",
     "debug": "^2.2.0",
     "electron-download": "^2.0.0",
     "electron-osx-sign": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "get-package-info": "^0.1.0",
     "minimist": "^1.1.1",
     "plist": "^1.1.0",
-    "rcedit": "^0.5.1",
+    "rcedit": "^0.7.0",
     "resolve": "^1.1.6",
     "run-series": "^1.1.1"
   },


### PR DESCRIPTION
- `asar@0.12.2`
  - Fixed a regression where generating large `.asar` files could cause `Maximum call stack size exceeded` errors
  - Upgraded to `minimatch@3.0.3` to address https://nodesecurity.io/advisories/minimatch_regular-expression-denial-of-service

- `rcedit@0.7.0`
  - Fixed issue where callback was called with `string` instead of `Error` when command failed
  - Improved error messages
  - Fixed issues setting values on non-English and/or .NET binaries

I believe #53 can now be closed after this gets merged, several errors are mentioned in that issue that have now been addressed in `rcedit` such as missing `.ddl` errors, non-ASCII path issues, and others.

Closes #53 