### PR TITLE
Default the prune option to true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 * Default the `platform` option to the host platform (#464)
 * Default the `arch` option to the host arch (#36, #464)
+* Default the `prune` option to `true`
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * Default the `platform` option to the host platform (#464)
 * Default the `arch` option to the host arch (#36, #464)
-* Default the `prune` option to `true`
+* Default the `prune` option to `true` (#235, #472)
 
 ### Fixed
 

--- a/common.js
+++ b/common.js
@@ -195,7 +195,7 @@ module.exports = {
     // * Creates temporary directory
     // * Copies template into temporary directory
     // * Copies user's app into temporary directory
-    // * Prunes non-production node_modules (if opts.prune is not false)
+    // * Prunes non-production node_modules (if opts.prune is either truthy or undefined)
     // * Creates an asar (if opts.asar is set)
 
     var tempPath

--- a/common.js
+++ b/common.js
@@ -24,7 +24,8 @@ function parseCLIArgs (argv) {
     ],
     default: {
       'deref-symlinks': true,
-      'download.strictSSL': true
+      'download.strictSSL': true,
+      prune: true
     },
     string: [
       'out'
@@ -194,7 +195,7 @@ module.exports = {
     // * Creates temporary directory
     // * Copies template into temporary directory
     // * Copies user's app into temporary directory
-    // * Prunes non-production node_modules (if opts.prune is set)
+    // * Prunes non-production node_modules (if opts.prune is not false)
     // * Creates an asar (if opts.asar is set)
 
     var tempPath
@@ -243,7 +244,7 @@ module.exports = {
 
     // Prune and asar are now performed before platform-specific logic, primarily so that
     // appPath is predictable (e.g. before .app is renamed for mac)
-    if (opts.prune) {
+    if (opts.prune || opts.prune === undefined) {
       operations.push(function (cb) {
         debug('Running npm prune --production')
         child.exec('npm prune --production', {cwd: appPath}, cb)

--- a/docs/api.md
+++ b/docs/api.md
@@ -192,7 +192,7 @@ The non-`all` values correspond to the platform names used by [Electron releases
 
 ##### `prune`
 
-*Boolean*
+*Boolean* (default: `true`)
 
 Runs [`npm prune --production`](https://docs.npmjs.com/cli/prune) before starting to package the app.
 

--- a/readme.md
+++ b/readme.md
@@ -90,11 +90,12 @@ If `appname` is omitted, this will use the name specified by "productName" or "n
 You should be able to launch the app on the platform you built for. If not, check your settings and try again.
 
 **Be careful** not to include `node_modules` you don't want into your final app. If you put them in
-the `devDependencies` section of `package.json` and specify the `--prune` parameter, none of the
-modules related to those dependencies will be copied in the app bundles. In addition, folders like
-`.git` and `node_modules/.bin` will be ignored by default. You can use `--ignore` to ignore files
-and folders via a regular expression (*not* a [glob pattern](https://en.wikipedia.org/wiki/Glob_%28programming%29)).
-Examples include `--ignore=\.gitignore` or `--ignore="\.git(ignore|modules)"`.
+the `devDependencies` section of `package.json`, by default none of the modules related to those
+dependencies will be copied in the app bundles. (This behavior can be turned off with the
+`--no-prune` flag.) In addition, folders like `.git` and `node_modules/.bin` will be ignored by
+default. You can use `--ignore` to ignore files and folders via a regular expression (*not* a
+[glob pattern](https://en.wikipedia.org/wiki/Glob_%28programming%29)). Examples include
+`--ignore=\.gitignore` or `--ignore="\.git(ignore|modules)"`.
 
 #### Example
 

--- a/usage.txt
+++ b/usage.txt
@@ -42,13 +42,13 @@ download           a list of sub-options to pass to electron-download. They are 
 icon               the icon file to use as the icon for the app. Note: Format depends on platform.
 ignore             do not copy files into app whose filenames regex .match this string. See also:
                    https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#ignore
-                   and --prune.
+                   and --no-prune.
+no-prune           do not run `npm prune --production` on the app
 out                the dir to put the app into at the end. defaults to current working dir
 overwrite          if output directory for a platform already exists, replaces it rather than
                    skipping it
 platform           all, or one or more of: darwin, linux, mas, win32 (comma-delimited if multiple).
                    Defaults to the host platform
-no-prune           do not run `npm prune --production` on the app
 tmpdir             temp directory. Defaults to system temp directory, use --tmpdir=false to disable
                    use of a temporary directory.
 version            the version of Electron that is being packaged, see

--- a/usage.txt
+++ b/usage.txt
@@ -48,7 +48,7 @@ overwrite          if output directory for a platform already exists, replaces i
                    skipping it
 platform           all, or one or more of: darwin, linux, mas, win32 (comma-delimited if multiple).
                    Defaults to the host platform
-prune              runs `npm prune --production` on the app
+no-prune           do not run `npm prune --production` on the app
 tmpdir             temp directory. Defaults to system temp directory, use --tmpdir=false to disable
                    use of a temporary directory.
 version            the version of Electron that is being packaged, see


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

In both the CLI and API, `prune` defaults to `true` (the CLI is just more explicit about it in the code).

@zeke I know you assigned yourself to #35 but I had some time the other day to work on this.

Addresses #35. (Obviously, not the `asar` part.)
Fixes #235.

**Are your changes appropriately documented?**

The CLI docs now mentions `--no-prune` instead of `--prune`. Also updated NEWS, the readme, and the API docs.

**Do your changes have sufficient test coverage?**

Updated the defaults test, added a test for prune=false.

**Does the testsuite pass successfully on your local machine?**

Yes
## TODO

* [x] truthy or undefined *([ref](#discussion_r76352707))*
* [x] `--no-prune` should go after `ignore` now to keep things alphabetical *([ref](#discussion_r76538010))*