### PR TITLE
Add Linux ARMv7 support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,11 @@
 ### Added
 
 * `win32metadata` option (#331, #463)
+* `linux` platform, `armv7l` arch support (#106, #474)
 
 ### Changed
 
+* `all` now includes the `linux` platform, `armv7l` arch combination
 * Default the `platform` option to the host platform (#464)
 * Default the `arch` option to the host arch (#36, #464)
 * Default the `prune` option to `true` (#235, #472)

--- a/common.js
+++ b/common.js
@@ -3,6 +3,7 @@
 const asar = require('asar')
 const child = require('child_process')
 const debug = require('debug')('electron-packager')
+const download = require('electron-download')
 const fs = require('fs-extra')
 const ignore = require('./ignore')
 const minimist = require('minimist')
@@ -81,6 +82,10 @@ function asarApp (appPath, asarOptions, cb) {
   })
 }
 
+function isPlatformMac (platform) {
+  return platform === 'darwin' || platform === 'mas'
+}
+
 function sanitizeAppName (name) {
   return sanitize(name, {replacement: '-'})
 }
@@ -116,28 +121,45 @@ function createAsarOpts (opts) {
   return asarOptions
 }
 
+function createDownloadOpts (opts, platform, arch) {
+  let downloadOpts = opts.download || {}
+
+  subOptionWarning(downloadOpts, 'download', 'platform', platform)
+  subOptionWarning(downloadOpts, 'download', 'arch', arch)
+  subOptionWarning(downloadOpts, 'download', 'version', opts.version)
+
+  return downloadOpts
+}
+
 module.exports = {
   archs: archs,
   platforms: platforms,
 
   parseCLIArgs: parseCLIArgs,
 
-  isPlatformMac: function isPlatformMac (platform) {
-    return platform === 'darwin' || platform === 'mas'
-  },
+  isPlatformMac: isPlatformMac,
 
   subOptionWarning: subOptionWarning,
 
   createAsarOpts: createAsarOpts,
+  createDownloadOpts: createDownloadOpts,
+  createDownloadCombos: function createDownloadCombos (opts, selectedPlatforms, selectedArchs, ignoreFunc) {
+    let combinations = []
+    for (let arch of selectedArchs) {
+      for (let platform of selectedPlatforms) {
+        // Electron does not have 32-bit releases for Mac OS X, so skip that combination
+        if (isPlatformMac(platform) && arch === 'ia32') continue
+        if (typeof ignoreFunc === 'function' && ignoreFunc(platform, arch)) continue
+        combinations.push(createDownloadOpts(opts, platform, arch))
+      }
+    }
 
-  createDownloadOpts: function createDownloadOpts (opts, platform, arch) {
-    let downloadOpts = opts.download || {}
+    return combinations
+  },
 
-    subOptionWarning(downloadOpts, 'download', 'platform', platform)
-    subOptionWarning(downloadOpts, 'download', 'arch', arch)
-    subOptionWarning(downloadOpts, 'download', 'version', opts.version)
-
-    return downloadOpts
+  downloadElectronZip: function downloadElectronZip (downloadOpts, cb) {
+    debug(`Downloading Electron with options ${JSON.stringify(downloadOpts)}`)
+    download(downloadOpts, cb)
   },
 
   generateFinalBasename: generateFinalBasename,

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,7 +67,7 @@ The release version of the application. By default the `version` property in the
 
 *String* (default: the arch of the host computer running Node)
 
-Allowed values: `ia32`, `x64`, `all`
+Allowed values: `ia32`, `x64`, `armv7l`, `all`
 
 The target system architecture(s) to build for.
 Not required if the [`all`](#all) option is set.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "rcedit": "^0.7.0",
     "resolve": "^1.1.6",
     "run-series": "^1.1.1",
-    "sanitize-filename": "^1.6.0"
+    "sanitize-filename": "^1.6.0",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "buffer-equal": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ It generates executables/bundles for the following **target** platforms:
 
 * Windows (also known as `win32`, for both 32/64 bit)
 * OS X (also known as `darwin`) / [Mac App Store](http://electron.atom.io/docs/v0.36.0/tutorial/mac-app-store-submission-guide/) (also known as `mas`)<sup>*</sup>
-* Linux (for both x86/x86_64)
+* Linux (for x86, x86_64, and armv7l architectures)
 
 <sup>*</sup> *Note for OS X / MAS target bundles: the `.app` bundle can only be signed when building on a host OS X platform.*
 

--- a/targets.js
+++ b/targets.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const common = require('./common')
+
+module.exports = {
+  supportedArchs: common.archs.reduce((result, arch) => {
+    result[arch] = true
+    return result
+  }, {}),
+  // Maps to module filename for each platform (lazy-required if used)
+  supportedPlatforms: {
+    darwin: './mac',
+    linux: './linux',
+    mas: './mac', // map to darwin
+    win32: './win32'
+  },
+
+  // Validates list of architectures or platforms.
+  // Returns a normalized array if successful, or throws an Error.
+  validateListFromOptions: function validateListFromOptions (opts, supported, name) {
+    if (opts.all) return Object.keys(supported)
+
+    let list = opts[name] || process[name]
+    if (list === 'all') return Object.keys(supported)
+
+    if (!Array.isArray(list)) list = list.split(',')
+    for (let value of list) {
+      if (!supported[value]) {
+        return new Error(`Unsupported ${name}=${value}; must be one of: ${Object.keys(supported).join(', ')}`)
+      }
+    }
+
+    return list
+  }
+}

--- a/test/basic.js
+++ b/test/basic.js
@@ -446,11 +446,8 @@ test('building for Linux target sanitizes binary name', (t) => {
 util.teardown()
 
 util.setup()
-test('fails with invalid arch', function (t) {
+test('fails with invalid arch', (t) => {
   var opts = {
-    name: 'el0374Test',
-    dir: path.join(__dirname, 'fixtures', 'el-0374'),
-    version: '0.37.4',
     arch: 'z80',
     platform: 'linux'
   }
@@ -463,11 +460,8 @@ test('fails with invalid arch', function (t) {
 util.teardown()
 
 util.setup()
-test('fails with invalid platform', function (t) {
+test('fails with invalid platform', (t) => {
   var opts = {
-    name: 'el0374Test',
-    dir: path.join(__dirname, 'fixtures', 'el-0374'),
-    version: '0.37.4',
     arch: 'ia32',
     platform: 'dos'
   }

--- a/test/multitarget.js
+++ b/test/multitarget.js
@@ -25,7 +25,7 @@ function verifyPackageExistence (finalPaths, callback) {
 
 util.setup()
 test('all test', function (t) {
-  t.timeoutAfter(config.timeout * 5) // 4-5 packages will be built during this test
+  t.timeoutAfter(config.timeout * 7) // 5-7 packages will be built during this test
 
   var opts = {
     name: 'basicTest',
@@ -34,13 +34,13 @@ test('all test', function (t) {
     all: true
   }
 
-  var expectedAppCount = 6
+  var expectedAppCount = 7
 
   waterfall([
     function (cb) {
       if (process.platform === 'win32') {
         isAdmin().then((admin) => {
-          if (!admin) expectedAppCount = 4
+          if (!admin) expectedAppCount = 5
           cb()
         })
       } else {
@@ -92,8 +92,9 @@ test('platform=all test (one arch)', function (t) {
 util.teardown()
 
 util.setup()
-test('arch=all test (one platform)', function (t) {
-  t.timeoutAfter(config.timeout * 2) // 2 packages will be built during this test
+test('arch=all test (one platform)', (t) => {
+  const LINUX_ARCH_COUNT = 3
+  t.timeoutAfter(config.timeout * LINUX_ARCH_COUNT)
 
   var opts = {
     name: 'basicTest',
@@ -107,10 +108,10 @@ test('arch=all test (one platform)', function (t) {
     function (cb) {
       packager(opts, cb)
     }, function (finalPaths, cb) {
-      t.equal(finalPaths.length, 2, 'packager call should resolve with expected number of paths')
+      t.equal(finalPaths.length, LINUX_ARCH_COUNT, 'packager call should resolve with expected number of paths')
       verifyPackageExistence(finalPaths, cb)
     }, function (exists, cb) {
-      t.true(exists, 'Packages should be generated for both architectures')
+      t.true(exists, 'Packages should be generated for all expected architectures')
       cb()
     }
   ], function (err) {

--- a/usage.txt
+++ b/usage.txt
@@ -17,8 +17,8 @@ appname            the name of the app, if it needs to be different from the "pr
 all                equivalent to --platform=all --arch=all
 app-copyright      human-readable copyright line for the app
 app-version        release version to set for the app
-arch               all, or one or more of: ia32, x64 (comma-delimited if multiple). Defaults to
-                   the host arch
+arch               all, or one or more of: ia32, x64, armv7l (comma-delimited if multiple). Defaults
+                   to the host arch
 asar               whether to package the source code within your app into an archive. You can either
                    pass --asar by itself to use the default configuration, OR use dot notation to
                    configure a list of sub-properties, e.g. --asar.unpackDir=sub_dir - do not use


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

Electron has had Linux ARM support since 0.29.0, but I have been hesitant to merge any PRs for it until Electron properly tagged its downloads with the correct version of the ARM processor that it supports<sup>[1](#note-1)</sup>. In this case, ARMv7. Fortunately, this is now on the horizon.

However, according to the Electron PR, the properly named ARM builds will only be backported to versions >= 1.0.0. We will support Electron versions 0.29.0 and above by modifying the arguments passed to `electron-download` to use the old name when the Electron version is less than 1.0.0. This means that a new dependency is required: `semver`, which checks what Electron version is being specified.

***Blocked by the release of https://github.com/electron/electron/pull/6986*** (cc @kevinsawicki :smile:).
Fixes #106.
Closes #107, #423.

**Are your changes appropriately documented?**

Added documentation about the new supported arch to the CLI and API docs, readme, and NEWS.

**Do your changes have sufficient test coverage?**

Updated the relevant multitarget tests.

**Does the testsuite pass successfully on your local machine?**

Yes

<sup id="note-1">1</sup>: *It didn't help that the PRs in question didn't have corresponding tests/docs.*

## TODO

* [x] Fix superfluous download option warnings
* [x] Uncomment semver code (and use `semver.lt`)