### PR TITLE
Upgrade asar for multibyte character in path support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
-    "asar": "^0.12.2",
+    "asar": "^0.12.3",
     "debug": "^2.2.0",
     "electron-download": "^2.0.0",
     "electron-osx-sign": "^0.3.0",


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Indeed

**Summarize your changes:**

Upgrade `asar` to `0.12.3` which added support for multibyte characters in paths. Previously this would lead to errors when packaging/loading an app that included a file or folder with a multibyte character in its name.

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

N/A

**Does the testsuite pass successfully on your local machine?**

Yes


