### PR TITLE
Sanitize ignores created when the output dir resolves to CWD

### DIFF
--- a/common.js
+++ b/common.js
@@ -99,6 +99,27 @@ function subOptionWarning (properties, optionName, parameter, value) {
   properties[parameter] = value
 }
 
+function generateOutIgnores (opts) {
+  let normalizedOut = opts.out ? path.resolve(opts.out) : null
+  let outIgnores = []
+  if (normalizedOut === null || normalizedOut === process.cwd()) {
+    for (let platform in platforms) {
+      for (let arch in archs) {
+        let basenameOpts = {
+          arch: arch,
+          name: opts.name,
+          platform: platform
+        }
+        outIgnores.push(path.join(process.cwd(), generateFinalBasename(basenameOpts)))
+      }
+    }
+  } else {
+    outIgnores.push(normalizedOut)
+  }
+
+  return outIgnores
+}
+
 function userIgnoreFilter (opts) {
   var ignore = opts.ignore || []
   var ignoreFunc = null
@@ -119,22 +140,7 @@ function userIgnoreFilter (opts) {
     }
   }
 
-  var normalizedOut = opts.out ? path.resolve(opts.out) : null
-  var outIgnores = []
-  if (normalizedOut === null || normalizedOut === process.cwd()) {
-    platforms.forEach(function (platform) {
-      archs.forEach(function (arch) {
-        let basenameOpts = {
-          arch: arch,
-          name: opts.name,
-          platform: platform
-        }
-        outIgnores.push(path.join(process.cwd(), generateFinalBasename(basenameOpts)))
-      })
-    })
-  } else {
-    outIgnores.push(normalizedOut)
-  }
+  let outIgnores = generateOutIgnores(opts)
 
   debug('Ignored paths based on the out param:', outIgnores)
 
@@ -194,6 +200,7 @@ module.exports = {
     return downloadOpts
   },
 
+  generateOutIgnores: generateOutIgnores,
   generateFinalBasename: generateFinalBasename,
   generateFinalPath: generateFinalPath,
 

--- a/common.js
+++ b/common.js
@@ -124,12 +124,19 @@ function userIgnoreFilter (opts) {
   if (normalizedOut === null || normalizedOut === process.cwd()) {
     platforms.forEach(function (platform) {
       archs.forEach(function (arch) {
-        outIgnores.push(path.join(process.cwd(), `${opts.name}-${platform}-${arch}`))
+        let basenameOpts = {
+          arch: arch,
+          name: opts.name,
+          platform: platform
+        }
+        outIgnores.push(path.join(process.cwd(), generateFinalBasename(basenameOpts)))
       })
     })
   } else {
     outIgnores.push(normalizedOut)
   }
+
+  debug('Ignored paths based on the out param:', outIgnores)
 
   return function filter (file) {
     if (outIgnores.indexOf(file) !== -1) {

--- a/ignore.js
+++ b/ignore.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const debug = require('debug')('electron-packager')
+const path = require('path')
+
+const DEFAULT_IGNORES = [
+  '/node_modules/electron($|/)',
+  '/node_modules/electron-prebuilt($|/)',
+  '/node_modules/electron-packager($|/)',
+  '/\\.git($|/)',
+  '/node_modules/\\.bin($|/)'
+]
+
+function generateIgnores (opts) {
+  if (typeof (opts.ignore) !== 'function') {
+    if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
+    opts.ignore = (opts.ignore) ? opts.ignore.concat(DEFAULT_IGNORES) : DEFAULT_IGNORES
+
+    debug('Ignored path regular expressions:', opts.ignore)
+  }
+}
+
+function generateOutIgnores (opts) {
+  // Avoid a circular require that breaks things
+  const common = require('./common')
+
+  let normalizedOut = opts.out ? path.resolve(opts.out) : null
+  let outIgnores = []
+  if (normalizedOut === null || normalizedOut === process.cwd()) {
+    for (let platform of common.platforms) {
+      for (let arch of common.archs) {
+        let basenameOpts = {
+          arch: arch,
+          name: opts.name,
+          platform: platform
+        }
+        outIgnores.push(path.join(process.cwd(), common.generateFinalBasename(basenameOpts)))
+      }
+    }
+  } else {
+    outIgnores.push(normalizedOut)
+  }
+
+  debug('Ignored paths based on the out param:', outIgnores)
+
+  return outIgnores
+}
+
+function userIgnoreFilter (opts) {
+  var ignore = opts.ignore || []
+  var ignoreFunc = null
+
+  if (typeof (ignore) === 'function') {
+    ignoreFunc = file => { return !ignore(file) }
+  } else {
+    if (!Array.isArray(ignore)) ignore = [ignore]
+
+    ignoreFunc = function filterByRegexes (file) {
+      for (var i = 0; i < ignore.length; i++) {
+        if (file.match(ignore[i])) {
+          return false
+        }
+      }
+
+      return true
+    }
+  }
+
+  let outIgnores = generateOutIgnores(opts)
+
+  return function filter (file) {
+    if (outIgnores.indexOf(file) !== -1) {
+      return false
+    }
+
+    var name = file.split(path.resolve(opts.dir))[1]
+
+    if (path.sep === '\\') {
+      // convert slashes so unix-format ignores work
+      name = name.replace(/\\/g, '/')
+    }
+
+    return ignoreFunc(name)
+  }
+}
+
+module.exports = {
+  generateIgnores: generateIgnores,
+  generateOutIgnores: generateOutIgnores,
+  userIgnoreFilter: userIgnoreFilter
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const download = require('electron-download')
 const extract = require('extract-zip')
 const fs = require('fs-extra')
 const getPackageInfo = require('get-package-info')
+const ignore = require('./ignore')
 const metadata = require('./package.json')
 const os = require('os')
 const path = require('path')
@@ -250,21 +251,7 @@ module.exports = function packager (opts, cb) {
     debug(`Application name: ${opts.name}`)
     debug(`Target Electron version: ${opts.version}`)
 
-    // Ignore this and related modules by default
-    var defaultIgnores = [
-      '/node_modules/electron($|/)',
-      '/node_modules/electron-prebuilt($|/)',
-      '/node_modules/electron-packager($|/)',
-      '/\\.git($|/)',
-      '/node_modules/\\.bin($|/)'
-    ]
-
-    if (typeof (opts.ignore) !== 'function') {
-      if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
-      opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
-
-      debug(`Ignored path regular expressions:\n${opts.ignore.map(function (ignore) { return `* ${ignore}` }).join('\n')}`)
-    }
+    ignore.generateIgnores(opts)
 
     series(createSeries(opts, archs, platforms), function (err, appPaths) {
       if (err) return cb(err)

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -3,6 +3,7 @@
 const common = require('../common')
 const config = require('./config.json')
 const fs = require('fs-extra')
+const ignore = require('../ignore')
 const path = require('path')
 const packager = require('..')
 const series = require('run-series')
@@ -129,7 +130,7 @@ function createIgnoreImplicitOutDirTest (opts) {
 }
 
 test('generateOutIgnores ignores all possible platform/arch permutations', (t) => {
-  let ignores = common.generateOutIgnores({name: 'test'})
+  let ignores = ignore.generateOutIgnores({name: 'test'})
   t.equal(ignores.length, common.platforms.length * common.archs.length)
   t.end()
 })

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -12,7 +12,7 @@ const util = require('./util')
 const waterfall = require('run-waterfall')
 
 function createIgnoreTest (opts, ignorePattern, ignoredFile) {
-  return function (t) {
+  return (t) => {
     t.timeoutAfter(config.timeout)
 
     opts.name = 'basicTest'
@@ -22,26 +22,26 @@ function createIgnoreTest (opts, ignorePattern, ignoredFile) {
     var appPath
 
     waterfall([
-      function (cb) {
+      (cb) => {
         packager(opts, cb)
-      }, function (paths, cb) {
+      }, (paths, cb) => {
         appPath = path.join(paths[0], util.generateResourcesPath(opts), 'app')
         fs.stat(path.join(appPath, 'package.json'), cb)
-      }, function (stats, cb) {
+      }, (stats, cb) => {
         t.true(stats.isFile(), 'The expected output directory should exist and contain files')
-        fs.exists(path.join(appPath, ignoredFile), function (exists) {
+        fs.exists(path.join(appPath, ignoredFile), exists => {
           t.false(exists, 'Ignored file should not exist in output app directory')
           cb()
         })
       }
-    ], function (err) {
+    ], (err) => {
       t.end(err)
     })
   }
 }
 
 function createIgnoreOutDirTest (opts, distPath) {
-  return function (t) {
+  return (t) => {
     t.timeoutAfter(config.timeout)
 
     opts.name = 'basicTest'
@@ -53,39 +53,41 @@ function createIgnoreOutDirTest (opts, distPath) {
     opts.out = outDir
 
     series([
-      function (cb) {
-        fs.copy(util.fixtureSubdir('basic'), appDir, {dereference: true, stopOnErr: true, filter: function (file) {
-          return path.basename(file) !== 'node_modules'
-        }}, cb)
+      (cb) => {
+        fs.copy(util.fixtureSubdir('basic'), appDir, {
+          dereference: true,
+          stopOnErr: true,
+          filter: file => { return path.basename(file) !== 'node_modules' }
+        }, cb)
       },
-      function (cb) {
+      (cb) => {
         // create out dir before packager (real world issue - when second run includes uningnored out dir)
         fs.mkdirp(outDir, cb)
       },
-      function (cb) {
+      (cb) => {
         // create file to ensure that directory will be not ignored because empty
-        fs.open(path.join(outDir, 'ignoreMe'), 'w', function (err, fd) {
+        fs.open(path.join(outDir, 'ignoreMe'), 'w', (err, fd) => {
           if (err) return cb(err)
           fs.close(fd, cb)
         })
       },
-      function (cb) {
+      (cb) => {
         packager(opts, cb)
       },
-      function (cb) {
-        fs.exists(path.join(outDir, common.generateFinalBasename(opts), util.generateResourcesPath(opts), 'app', path.basename(outDir)), function (exists) {
+      (cb) => {
+        fs.exists(path.join(outDir, common.generateFinalBasename(opts), util.generateResourcesPath(opts), 'app', path.basename(outDir)), (exists) => {
           t.false(exists, 'Out dir must not exist in output app directory')
           cb()
         })
       }
-    ], function (err) {
+    ], (err) => {
       t.end(err)
     })
   }
 }
 
 function createIgnoreImplicitOutDirTest (opts) {
-  return function (t) {
+  return (t) => {
     t.timeoutAfter(config.timeout)
 
     opts.name = 'basicTest'
@@ -98,32 +100,34 @@ function createIgnoreImplicitOutDirTest (opts) {
     var previousPackedResultDir
 
     series([
-      function (cb) {
-        fs.copy(util.fixtureSubdir('basic'), appDir, {dereference: true, stopOnErr: true, filter: function (file) {
-          return path.basename(file) !== 'node_modules'
-        }}, cb)
+      (cb) => {
+        fs.copy(util.fixtureSubdir('basic'), appDir, {
+          dereference: true,
+          stopOnErr: true,
+          filter: file => { return path.basename(file) !== 'node_modules' }
+        }, cb)
       },
-      function (cb) {
+      (cb) => {
         previousPackedResultDir = path.join(outDir, `${common.sanitizeAppName(opts.name)}-linux-ia32`)
         fs.mkdirp(previousPackedResultDir, cb)
       },
-      function (cb) {
+      (cb) => {
         // create file to ensure that directory will be not ignored because empty
-        fs.open(path.join(previousPackedResultDir, testFilename), 'w', function (err, fd) {
+        fs.open(path.join(previousPackedResultDir, testFilename), 'w', (err, fd) => {
           if (err) return cb(err)
           fs.close(fd, cb)
         })
       },
-      function (cb) {
+      (cb) => {
         packager(opts, cb)
       },
-      function (cb) {
-        fs.exists(path.join(outDir, common.generateFinalBasename(opts), util.generateResourcesPath(opts), 'app', testFilename), function (exists) {
+      (cb) => {
+        fs.exists(path.join(outDir, common.generateFinalBasename(opts), util.generateResourcesPath(opts), 'app', testFilename), (exists) => {
           t.false(exists, 'Out dir must not exist in output app directory')
           cb()
         })
       }
-    ], function (err) {
+    ], (err) => {
       t.end(err)
     })
   }
@@ -140,7 +144,7 @@ util.testSinglePlatform('ignore test: string in array', createIgnoreTest, ['igno
 util.testSinglePlatform('ignore test: string', createIgnoreTest, 'ignorethis', 'ignorethis.txt')
 util.testSinglePlatform('ignore test: RegExp', createIgnoreTest, /ignorethis/, 'ignorethis.txt')
 util.testSinglePlatform('ignore test: Function', createIgnoreTest,
-                        function (file) { return file.match(/ignorethis/) }, 'ignorethis.txt')
+                        file => { return file.match(/ignorethis/) }, 'ignorethis.txt')
 util.testSinglePlatform('ignore test: string with slash', createIgnoreTest, 'ignore/this',
   path.join('ignore', 'this.txt'))
 util.testSinglePlatform('ignore test: only match subfolder of app', createIgnoreTest,

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -102,7 +102,7 @@ function createIgnoreImplicitOutDirTest (opts) {
         }}, cb)
       },
       function (cb) {
-        previousPackedResultDir = path.join(outDir, `${opts.name}-linux-ia32`)
+        previousPackedResultDir = path.join(outDir, `${common.sanitizeAppName(opts.name)}-linux-ia32`)
         fs.mkdirp(previousPackedResultDir, cb)
       },
       function (cb) {

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const packager = require('..')
 const series = require('run-series')
+const test = require('tape')
 const util = require('./util')
 const waterfall = require('run-waterfall')
 
@@ -126,6 +127,12 @@ function createIgnoreImplicitOutDirTest (opts) {
     })
   }
 }
+
+test('generateOutIgnores ignores all possible platform/arch permutations', (t) => {
+  let ignores = common.generateOutIgnores({name: 'test'})
+  t.equal(ignores.length, common.platforms.length * common.archs.length)
+  t.end()
+})
 
 util.testSinglePlatform('ignore test: string in array', createIgnoreTest, ['ignorethis'],
                         'ignorethis.txt')


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

First and foremost, this fixes a regression that was introduced in #455 - the ignores generated when the `out` option resolves to the current working directory were not having their basenames properly sanitized.

While I was in there, I also ES6ified the ignore code (including the tests) and refactored out all of the ignore-related code into its own file. The one downside to that is that I had to introduce a function-level require to one of the ignore functions, in order to avoid nonfunctional circular requires.

**Are your changes appropriately documented?**

Not applicable

**Do your changes have sufficient test coverage?**

Added a test for the new `generateOutIgnores()`.

**Does the testsuite pass successfully on your local machine?**

Yes
