### PR TITLE
DRY up some test code

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -419,8 +419,7 @@ util.testSinglePlatform('tmpdir test', createTmpdirTest)
 util.testSinglePlatform('tmpdir test', createDisableTmpdirUsingTest)
 util.testSinglePlatform('deref symlink test', createDisableSymlinkDereferencingTest)
 
-util.setup()
-test('building for Linux target sanitizes binary name', (t) => {
+util.packagerTest('building for Linux target sanitizes binary name', (t) => {
   let opts = {
     name: '@username/package-name',
     dir: path.join(__dirname, 'fixtures', 'el-0374'),
@@ -443,65 +442,56 @@ test('building for Linux target sanitizes binary name', (t) => {
     t.end(err)
   })
 })
-util.teardown()
 
-util.setup()
-test('fails with invalid arch', (t) => {
-  var opts = {
+util.packagerTest('fails with invalid arch', (t) => {
+  let opts = {
     arch: 'z80',
     platform: 'linux'
   }
-  packager(opts, function (err, paths) {
+  packager(opts, (err, paths) => {
     t.equal(undefined, paths, 'no paths returned')
     t.ok(err, 'error thrown')
     t.end()
   })
 })
-util.teardown()
 
-util.setup()
-test('fails with invalid platform', (t) => {
-  var opts = {
+util.packagerTest('fails with invalid platform', (t) => {
+  let opts = {
     arch: 'ia32',
     platform: 'dos'
   }
-  packager(opts, function (err, paths) {
+  packager(opts, (err, paths) => {
     t.equal(undefined, paths, 'no paths returned')
     t.ok(err, 'error thrown')
     t.end()
   })
 })
-util.teardown()
 
-util.setup()
-test('fails with invalid version', function (t) {
-  var opts = {
+util.packagerTest('fails with invalid version', (t) => {
+  let opts = {
     name: 'invalidElectronTest',
     dir: path.join(__dirname, 'fixtures', 'el-0374'),
     version: '0.0.1',
     arch: 'x64',
     platform: 'linux'
   }
-  packager(opts, function (err, paths) {
+  packager(opts, (err, paths) => {
     t.equal(undefined, paths, 'no paths returned')
     t.ok(err, 'error thrown')
     t.end()
   })
 })
-util.teardown()
 
-util.setup()
-test('dir argument test: should work with relative path', function (t) {
-  var opts = {
+util.packagerTest('dir argument test: should work with relative path', (t) => {
+  let opts = {
     name: 'ElectronTest',
     dir: path.join('..', 'fixtures', 'el-0374'),
     version: '0.37.4',
     arch: 'x64',
     platform: 'linux'
   }
-  packager(opts, function (err, paths) {
+  packager(opts, (err, paths) => {
     t.equal(path.join(__dirname, 'work', 'ElectronTest-linux-x64'), paths[0], 'paths returned')
     t.end(err)
   })
 })
-util.teardown()

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,25 +1,9 @@
 'use strict'
 
 const config = require('./config.json')
-const fs = require('fs')
 const packager = require('..')
-const series = require('run-series')
 const util = require('./util')
 const waterfall = require('run-waterfall')
-
-function verifyPackageExistence (finalPaths, callback) {
-  series(finalPaths.map(function (finalPath) {
-    return function (cb) {
-      fs.stat(finalPath, cb)
-    }
-  }), function (err, statsResults) {
-    if (err) return callback(null, false)
-
-    callback(null, statsResults.every(function (stats) {
-      return stats.isDirectory()
-    }))
-  })
-}
 
 function createHookTest (hookName) {
   util.packagerTest('platform=all test (one arch) (' + hookName + ' hook)', (t) => {
@@ -47,7 +31,7 @@ function createHookTest (hookName) {
       }, function (finalPaths, cb) {
         t.equal(finalPaths.length, 2, 'packager call should resolve with expected number of paths')
         t.true(hookCalled, hookName + ' methods should have been called')
-        verifyPackageExistence(finalPaths, cb)
+        util.verifyPackageExistence(finalPaths, cb)
       }, function (exists, cb) {
         t.true(exists, 'Packages should be generated for both 32-bit platforms')
         cb()

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -4,7 +4,6 @@ const config = require('./config.json')
 const fs = require('fs')
 const packager = require('..')
 const series = require('run-series')
-const test = require('tape')
 const util = require('./util')
 const waterfall = require('run-waterfall')
 
@@ -23,8 +22,7 @@ function verifyPackageExistence (finalPaths, callback) {
 }
 
 function createHookTest (hookName) {
-  util.setup()
-  test('platform=all test (one arch) (' + hookName + ' hook)', function (t) {
+  util.packagerTest('platform=all test (one arch) (' + hookName + ' hook)', (t) => {
     t.timeoutAfter(config.timeout * 2) // 2 packages will be built during this test
 
     var hookCalled = false
@@ -58,7 +56,6 @@ function createHookTest (hookName) {
       t.end(err)
     })
   })
-  util.teardown()
 }
 
 createHookTest('afterCopy')

--- a/test/mac.js
+++ b/test/mac.js
@@ -521,57 +521,32 @@ function createProtocolTest (baseOpts) {
 }
 
 // Share testing script with platform darwin and mas
-module.exports = function (baseOpts) {
-  util.setup()
-  test('helper app paths test', createHelperAppPathsTest(baseOpts))
-  util.teardown()
-
-  util.setup()
-  test('helper app paths test with app name needing sanitization', createHelperAppPathsTest(Object.assign({}, baseOpts, {name: '@username/package-name'}), '@username-package-name'))
-  util.teardown()
-
-  var iconBase = path.join(__dirname, 'fixtures', 'monochrome')
-  var icnsPath = iconBase + '.icns'
-  util.setup()
-  test('icon test: .icns specified', createIconTest(baseOpts, icnsPath, icnsPath))
-  util.teardown()
-
-  var el0374Opts = {
+module.exports = (baseOpts) => {
+  let iconBase = path.join(__dirname, 'fixtures', 'monochrome')
+  let icnsPath = iconBase + '.icns'
+  let el0374Opts = {
     name: 'el0374Test',
     dir: util.fixtureSubdir('el-0374'),
     version: '0.37.4',
     arch: 'x64',
     platform: 'darwin'
   }
-  // use iconBase, icnsPath from previous test
-  util.setup()
-  test('icon test: el-0.37.4, .icns specified', createIconTest(el0374Opts, icnsPath, icnsPath))
-  util.teardown()
+  let extraInfoPath = path.join(__dirname, 'fixtures', 'extrainfo.plist')
 
-  util.setup()
-  test('icon test: .ico specified (should replace with .icns)', createIconTest(baseOpts, iconBase + '.ico', icnsPath))
-  util.teardown()
+  util.packagerTest('helper app paths test', createHelperAppPathsTest(baseOpts))
+  util.packagerTest('helper app paths test with app name needing sanitization', createHelperAppPathsTest(Object.assign({}, baseOpts, {name: '@username/package-name'}), '@username-package-name'))
 
-  util.setup()
-  test('icon test: basename only (should add .icns)', createIconTest(baseOpts, iconBase, icnsPath))
-  util.teardown()
+  util.packagerTest('icon test: .icns specified', createIconTest(baseOpts, icnsPath, icnsPath))
+  util.packagerTest('icon test: el-0.37.4, .icns specified', createIconTest(el0374Opts, icnsPath, icnsPath))
+  util.packagerTest('icon test: .ico specified (should replace with .icns)', createIconTest(baseOpts, iconBase + '.ico', icnsPath))
+  util.packagerTest('icon test: basename only (should add .icns)', createIconTest(baseOpts, iconBase, icnsPath))
 
-  var extraInfoPath = path.join(__dirname, 'fixtures', 'extrainfo.plist')
-  util.setup()
-  test('extend-info test', createExtendInfoTest(baseOpts, extraInfoPath))
-  util.teardown()
+  util.packagerTest('extend-info test', createExtendInfoTest(baseOpts, extraInfoPath))
 
-  util.setup()
-  test('extra-resource test: one arg', createExtraResourceTest(baseOpts))
-  util.teardown()
+  util.packagerTest('extra-resource test: one arg', createExtraResourceTest(baseOpts))
+  util.packagerTest('extra-resource test: two arg', createExtraResource2Test(baseOpts))
 
-  util.setup()
-  test('extra-resource test: two arg', createExtraResource2Test(baseOpts))
-  util.teardown()
-
-  util.setup()
-  test('protocol/protocol-name argument test', createProtocolTest(baseOpts))
-  util.teardown()
+  util.packagerTest('protocol/protocol-name argument test', createProtocolTest(baseOpts))
 
   test('osx-sign argument test: default args', function (t) {
     var args = true
@@ -615,8 +590,7 @@ module.exports = function (baseOpts) {
     t.end()
   })
 
-  util.setup()
-  test('codesign test', function (t) {
+  util.packagerTest('codesign test', (t) => {
     t.timeoutAfter(config.macExecTimeout)
 
     var opts = Object.create(baseOpts)
@@ -643,18 +617,11 @@ module.exports = function (baseOpts) {
       t.end(notFound ? null : err)
     })
   })
-  util.teardown()
 
-  util.setup()
-  test('binary naming test', createBinaryNameTest(baseOpts))
-  util.teardown()
+  util.packagerTest('binary naming test', createBinaryNameTest(baseOpts))
+  util.packagerTest('sanitized binary naming test', createBinaryNameTest(Object.assign({}, baseOpts, {name: '@username/package-name'}), '@username-package-name'))
 
-  util.setup()
-  test('sanitized binary naming test', createBinaryNameTest(Object.assign({}, baseOpts, {name: '@username/package-name'}), '@username-package-name'))
-  util.teardown()
-
-  util.setup()
-  test('CFBundleName is the sanitized app name and CFBundleDisplayName is the non-sanitized app name', (t) => {
+  util.packagerTest('CFBundleName is the sanitized app name and CFBundleDisplayName is the non-sanitized app name', (t) => {
     t.timeoutAfter(config.timeout)
 
     let plistPath
@@ -686,70 +653,28 @@ module.exports = function (baseOpts) {
       t.end(err)
     })
   })
-  util.teardown()
 
-  util.setup()
-  test('app and build version test', createAppVersionTest(baseOpts, '1.1.0', '1.1.0.1234'))
-  util.teardown()
+  util.packagerTest('app and build version test', createAppVersionTest(baseOpts, '1.1.0', '1.1.0.1234'))
+  util.packagerTest('infer app version from package.json test', createAppVersionInferenceTest(baseOpts))
+  util.packagerTest('app version test', createAppVersionTest(baseOpts, '1.1.0'))
+  util.packagerTest('app and build version integer test', createAppVersionTest(baseOpts, 12, 1234))
 
-  util.setup()
-  test('infer app version from package.json test', createAppVersionInferenceTest(baseOpts))
-  util.teardown()
+  util.packagerTest('app categoryType test', createAppCategoryTypeTest(baseOpts, 'public.app-category.developer-tools'))
 
-  util.setup()
-  test('app version test', createAppVersionTest(baseOpts, '1.1.0'))
-  util.teardown()
+  util.packagerTest('app bundle test', createAppBundleTest(baseOpts, 'com.electron.basetest'))
+  util.packagerTest('app bundle (w/ special characters) test', createAppBundleTest(baseOpts, 'com.electron."bãśè tëßt!@#$%^&*()?\''))
+  util.packagerTest('app bundle app-bundle-id fallback test', createAppBundleTest(baseOpts))
+  util.packagerTest('app bundle framework symlink test', createAppBundleFrameworkTest(baseOpts))
 
-  util.setup()
-  test('app and build version integer test', createAppVersionTest(baseOpts, 12, 1234))
-  util.teardown()
+  util.packagerTest('app helpers bundle test', createAppHelpersBundleTest(baseOpts, 'com.electron.basetest.helper'))
+  util.packagerTest('app helpers bundle (w/ special characters) test', createAppHelpersBundleTest(baseOpts, 'com.electron."bãśè tëßt!@#$%^&*()?\'.hęłpėr'))
+  util.packagerTest('app helpers bundle helper-bundle-id fallback to app-bundle-id test', createAppHelpersBundleTest(baseOpts, null, 'com.electron.basetest'))
+  util.packagerTest('app helpers bundle helper-bundle-id fallback to app-bundle-id (w/ special characters) test', createAppHelpersBundleTest(baseOpts, null, 'com.electron."bãśè tëßt!!@#$%^&*()?\''))
+  util.packagerTest('app helpers bundle helper-bundle-id & app-bundle-id fallback test', createAppHelpersBundleTest(baseOpts))
 
-  util.setup()
-  test('app categoryType test', createAppCategoryTypeTest(baseOpts, 'public.app-category.developer-tools'))
-  util.teardown()
+  util.packagerTest('app humanReadableCopyright test', createAppHumanReadableCopyrightTest(baseOpts, 'Copyright © 2003–2015 Organization. All rights reserved.'))
 
-  util.setup()
-  test('app bundle test', createAppBundleTest(baseOpts, 'com.electron.basetest'))
-  util.teardown()
-
-  util.setup()
-  test('app bundle (w/ special characters) test', createAppBundleTest(baseOpts, 'com.electron."bãśè tëßt!@#$%^&*()?\''))
-  util.teardown()
-
-  util.setup()
-  test('app bundle app-bundle-id fallback test', createAppBundleTest(baseOpts))
-  util.teardown()
-
-  util.setup()
-  test('app bundle framework symlink test', createAppBundleFrameworkTest(baseOpts))
-  util.teardown()
-
-  util.setup()
-  test('app helpers bundle test', createAppHelpersBundleTest(baseOpts, 'com.electron.basetest.helper'))
-  util.teardown()
-
-  util.setup()
-  test('app helpers bundle (w/ special characters) test', createAppHelpersBundleTest(baseOpts, 'com.electron."bãśè tëßt!@#$%^&*()?\'.hęłpėr'))
-  util.teardown()
-
-  util.setup()
-  test('app helpers bundle helper-bundle-id fallback to app-bundle-id test', createAppHelpersBundleTest(baseOpts, null, 'com.electron.basetest'))
-  util.teardown()
-
-  util.setup()
-  test('app helpers bundle helper-bundle-id fallback to app-bundle-id (w/ special characters) test', createAppHelpersBundleTest(baseOpts, null, 'com.electron."bãśè tëßt!!@#$%^&*()?\''))
-  util.teardown()
-
-  util.setup()
-  test('app helpers bundle helper-bundle-id & app-bundle-id fallback test', createAppHelpersBundleTest(baseOpts))
-  util.teardown()
-
-  util.setup()
-  test('app humanReadableCopyright test', createAppHumanReadableCopyrightTest(baseOpts, 'Copyright © 2003–2015 Organization. All rights reserved.'))
-  util.teardown()
-
-  util.setup()
-  test('app named Electron packaged successfully', (t) => {
+  util.packagerTest('app named Electron packaged successfully', (t) => {
     let opts = Object.create(baseOpts)
     opts.name = 'Electron'
     let appPath
@@ -771,5 +696,4 @@ module.exports = function (baseOpts) {
       t.end(err)
     })
   })
-  util.teardown()
 }

--- a/test/multitarget.js
+++ b/test/multitarget.js
@@ -5,7 +5,6 @@ const fs = require('fs')
 const isAdmin = require('is-admin')
 const packager = require('..')
 const series = require('run-series')
-const test = require('tape')
 const util = require('./util')
 const waterfall = require('run-waterfall')
 
@@ -23,8 +22,36 @@ function verifyPackageExistence (finalPaths, callback) {
   })
 }
 
-util.setup()
-test('all test', function (t) {
+function createMultiTest (arch, platform) {
+  return (t) => {
+    // 4 packages will be built during this test
+    t.timeoutAfter(config.timeout * 4)
+
+    var opts = {
+      name: 'basicTest',
+      dir: util.fixtureSubdir('basic'),
+      version: config.version,
+      arch: arch,
+      platform: platform
+    }
+
+    waterfall([
+      (cb) => {
+        packager(opts, cb)
+      }, (finalPaths, cb) => {
+        t.equal(finalPaths.length, 4, 'packager call should resolve with expected number of paths')
+        verifyPackageExistence(finalPaths, cb)
+      }, (exists, cb) => {
+        t.true(exists, 'Packages should be generated for all combinations of specified archs and platforms')
+        cb()
+      }
+    ], (err) => {
+      t.end(err)
+    })
+  }
+}
+
+util.packagerTest('all test', (t) => {
   t.timeoutAfter(config.timeout * 7) // 5-7 packages will be built during this test
 
   var opts = {
@@ -61,10 +88,8 @@ test('all test', function (t) {
     t.end(err)
   })
 })
-util.teardown()
 
-util.setup()
-test('platform=all test (one arch)', function (t) {
+util.packagerTest('platform=all test (one arch)', function (t) {
   t.timeoutAfter(config.timeout * 2) // 2 packages will be built during this test
 
   var opts = {
@@ -89,10 +114,8 @@ test('platform=all test (one arch)', function (t) {
     t.end(err)
   })
 })
-util.teardown()
 
-util.setup()
-test('arch=all test (one platform)', (t) => {
+util.packagerTest('arch=all test (one platform)', (t) => {
   const LINUX_ARCH_COUNT = 3
   t.timeoutAfter(config.timeout * LINUX_ARCH_COUNT)
 
@@ -118,41 +141,6 @@ test('arch=all test (one platform)', (t) => {
     t.end(err)
   })
 })
-util.teardown()
 
-function createMultiTest (arch, platform) {
-  return function (t) {
-    // 4 packages will be built during this test
-    t.timeoutAfter(config.timeout * 4)
-
-    var opts = {
-      name: 'basicTest',
-      dir: util.fixtureSubdir('basic'),
-      version: config.version,
-      arch: arch,
-      platform: platform
-    }
-
-    waterfall([
-      function (cb) {
-        packager(opts, cb)
-      }, function (finalPaths, cb) {
-        t.equal(finalPaths.length, 4, 'packager call should resolve with expected number of paths')
-        verifyPackageExistence(finalPaths, cb)
-      }, function (exists, cb) {
-        t.true(exists, 'Packages should be generated for all combinations of specified archs and platforms')
-        cb()
-      }
-    ], function (err) {
-      t.end(err)
-    })
-  }
-}
-
-util.setup()
-test('multi-platform / multi-arch test, from arrays', createMultiTest(['ia32', 'x64'], ['linux', 'win32']))
-util.teardown()
-
-util.setup()
-test('multi-platform / multi-arch test, from strings', createMultiTest('ia32,x64', 'linux,win32'))
-util.teardown()
+util.packagerTest('multi-platform / multi-arch test, from arrays', createMultiTest(['ia32', 'x64'], ['linux', 'win32']))
+util.packagerTest('multi-platform / multi-arch test, from strings', createMultiTest('ia32,x64', 'linux,win32'))

--- a/test/multitarget.js
+++ b/test/multitarget.js
@@ -1,26 +1,10 @@
 'use strict'
 
 const config = require('./config.json')
-const fs = require('fs')
 const isAdmin = require('is-admin')
 const packager = require('..')
-const series = require('run-series')
 const util = require('./util')
 const waterfall = require('run-waterfall')
-
-function verifyPackageExistence (finalPaths, callback) {
-  series(finalPaths.map(function (finalPath) {
-    return function (cb) {
-      fs.stat(finalPath, cb)
-    }
-  }), function (err, statsResults) {
-    if (err) return callback(null, false)
-
-    callback(null, statsResults.every(function (stats) {
-      return stats.isDirectory()
-    }))
-  })
-}
 
 function createMultiTest (arch, platform) {
   return (t) => {
@@ -40,7 +24,7 @@ function createMultiTest (arch, platform) {
         packager(opts, cb)
       }, (finalPaths, cb) => {
         t.equal(finalPaths.length, 4, 'packager call should resolve with expected number of paths')
-        verifyPackageExistence(finalPaths, cb)
+        util.verifyPackageExistence(finalPaths, cb)
       }, (exists, cb) => {
         t.true(exists, 'Packages should be generated for all combinations of specified archs and platforms')
         cb()
@@ -79,7 +63,7 @@ util.packagerTest('all test', (t) => {
       // OS X only has 64-bit releases
       t.equal(finalPaths.length, expectedAppCount,
         'packager call should resolve with expected number of paths')
-      verifyPackageExistence(finalPaths, cb)
+      util.verifyPackageExistence(finalPaths, cb)
     }, function (exists, cb) {
       t.true(exists, 'Packages should be generated for all possible platforms')
       cb()
@@ -105,7 +89,7 @@ util.packagerTest('platform=all test (one arch)', function (t) {
       packager(opts, cb)
     }, function (finalPaths, cb) {
       t.equal(finalPaths.length, 2, 'packager call should resolve with expected number of paths')
-      verifyPackageExistence(finalPaths, cb)
+      util.verifyPackageExistence(finalPaths, cb)
     }, function (exists, cb) {
       t.true(exists, 'Packages should be generated for both 32-bit platforms')
       cb()
@@ -132,7 +116,7 @@ util.packagerTest('arch=all test (one platform)', (t) => {
       packager(opts, cb)
     }, function (finalPaths, cb) {
       t.equal(finalPaths.length, LINUX_ARCH_COUNT, 'packager call should resolve with expected number of paths')
-      verifyPackageExistence(finalPaths, cb)
+      util.verifyPackageExistence(finalPaths, cb)
     }, function (exists, cb) {
       t.true(exists, 'Packages should be generated for all expected architectures')
       cb()

--- a/test/util.js
+++ b/test/util.js
@@ -88,3 +88,17 @@ exports.testSinglePlatform = function testSinglePlatform (name, createTest /*, .
   var args = slice.call(arguments, 2)
   exports.packagerTest(name, createTest.apply(null, [{platform: 'linux', arch: 'x64', version: config.version}].concat(args)))
 }
+
+exports.verifyPackageExistence = function verifyPackageExistence (finalPaths, callback) {
+  series(finalPaths.map((finalPath) => {
+    return (cb) => {
+      fs.stat(finalPath, cb)
+    }
+  }), (err, statsResults) => {
+    if (err) return callback(null, false)
+
+    callback(null, statsResults.every((stats) => {
+      return stats.isDirectory()
+    }))
+  })
+}

--- a/test/util.js
+++ b/test/util.js
@@ -78,9 +78,13 @@ exports.teardown = function teardown () {
   })
 }
 
+exports.packagerTest = function packagerTest (name, testFunction) {
+  exports.setup()
+  test(name, testFunction)
+  exports.teardown()
+}
+
 exports.testSinglePlatform = function testSinglePlatform (name, createTest /*, ...createTestArgs */) {
   var args = slice.call(arguments, 2)
-  exports.setup()
-  test(name, createTest.apply(null, [{platform: 'linux', arch: 'x64', version: config.version}].concat(args)))
-  exports.teardown()
+  exports.packagerTest(name, createTest.apply(null, [{platform: 'linux', arch: 'x64', version: config.version}].concat(args)))
 }

--- a/test/win32.js
+++ b/test/win32.js
@@ -134,8 +134,7 @@ test('error message unchanged when error not about wine', (t) => {
   t.end()
 })
 
-util.setup()
-test('win32 executable name is based on sanitized app name', (t) => {
+util.packagerTest('win32 executable name is based on sanitized app name', (t) => {
   let opts = Object.assign({}, baseOpts, {name: '@username/package-name'})
 
   waterfall([
@@ -153,28 +152,10 @@ test('win32 executable name is based on sanitized app name', (t) => {
     t.end(err)
   })
 })
-util.teardown()
 
-util.setup()
-test('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
-util.teardown()
-
-util.setup()
-test('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
-util.teardown()
-
-util.setup()
-test('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
-util.teardown()
-
-util.setup()
-test('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
-util.teardown()
-
-util.setup()
-test('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))
-util.teardown()
-
-util.setup()
-test('win32 set CompanyName test (version-string)', setCompanyNameTest('MyCompany LLC', 'version-string'))
-util.teardown()
+util.packagerTest('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
+util.packagerTest('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
+util.packagerTest('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
+util.packagerTest('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
+util.packagerTest('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))
+util.packagerTest('win32 set CompanyName test (version-string)', setCompanyNameTest('MyCompany LLC', 'version-string'))


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

* creates a new `util.packagerTest()`, which is a wrapper for `setup(); test(...); teardown();`
* Gets rid of a duplicate definition of `verifyPackageExistence()`
* Some ES6ifying during the process

**Are your changes appropriately documented?**

Not applicable

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes