### PR TITLE
Default build version to app version  on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 * Electron downloads are now checked against their published checksums (#493)
 * Documentation for `download.quiet` option to enable/disable progress bar (#494)
 * The `build-version` property, when unspecified, now defaults to the
-  `app-version` property value on Windows (#501).
+  `app-version` property value on Windows (#501)
 
 ## [8.0.0] - 2016-09-03
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * `.o` and `.obj` files are ignored by default (#491)
 * Electron downloads are now checked against their published checksums (#493)
 * Documentation for `download.quiet` option to enable/disable progress bar (#494)
+* The `build-version` property, when unspecified, now defaults to the
+  `app-version` property value on Windows (#501).
 
 ## [8.0.0] - 2016-09-03
 

--- a/test/win32.js
+++ b/test/win32.js
@@ -56,11 +56,11 @@ function setFileVersionTest (buildVersion) {
     'build-version': buildVersion
   }
 
-  return generateVersionStringTest(['FileVersion', 'ProductVersion'],
+  return generateVersionStringTest(['ProductVersion', 'FileVersion'],
                                    opts,
-                                   [buildVersion, '4.99.101.0'],
-                                   ['File version should match build version',
-                                    'Product version should match package.json version'])
+                                   ['4.99.101.0', buildVersion],
+                                   ['Product version should match package.json version',
+                                    'File version should match build version'])
 }
 
 function setProductVersionTest (appVersion) {

--- a/test/win32.js
+++ b/test/win32.js
@@ -171,7 +171,7 @@ util.packagerTest('win32 executable name is based on sanitized app name', (t) =>
 
 util.packagerTest('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
 util.packagerTest('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
-util.packagerTest('win32 app/build version default to package.json test', defaultProductAndFileVersionToPackageVersionTest())
+util.packagerTest('win32 app/build versions default to package.json version test', defaultProductAndFileVersionToPackageVersionTest())
 util.packagerTest('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
 util.packagerTest('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
 util.packagerTest('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))

--- a/test/win32.js
+++ b/test/win32.js
@@ -56,7 +56,11 @@ function setFileVersionTest (buildVersion) {
     'build-version': buildVersion
   }
 
-  return generateVersionStringTest('FileVersion', opts, buildVersion, 'File version should match build version')
+  return generateVersionStringTest(['FileVersion', 'ProductVersion'],
+                                   opts,
+                                   [buildVersion, '4.99.101.0'],
+                                   ['File version should match build version',
+                                    'Product version should match package.json version'])
 }
 
 function setProductVersionTest (appVersion) {
@@ -64,7 +68,19 @@ function setProductVersionTest (appVersion) {
     'app-version': appVersion
   }
 
-  return generateVersionStringTest('ProductVersion', opts, appVersion, 'Product version should match app version')
+  return generateVersionStringTest(['ProductVersion', 'FileVersion'],
+                                   opts,
+                                   [appVersion, appVersion],
+                                   ['Product version should match app version',
+                                    'File version should match app version'])
+}
+
+function defaultProductAndFileVersionToPackageVersionTest () {
+  return generateVersionStringTest(['ProductVersion', 'FileVersion'],
+                                   {},
+                                   ['4.99.101.0', '4.99.101.0'],
+                                   ['Product version should match package.json version',
+                                    'File version should match package.json version'])
 }
 
 function setCopyrightTest (appCopyright) {
@@ -155,6 +171,7 @@ util.packagerTest('win32 executable name is based on sanitized app name', (t) =>
 
 util.packagerTest('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
 util.packagerTest('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
+util.packagerTest('win32 app/build version default to package.json test', defaultProductAndFileVersionToPackageVersionTest())
 util.packagerTest('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
 util.packagerTest('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
 util.packagerTest('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))

--- a/win32.js
+++ b/win32.js
@@ -33,12 +33,12 @@ module.exports = {
 
       var rcOpts = {'version-string': win32metadata}
 
-      if (opts['build-version']) {
-        rcOpts['file-version'] = opts['build-version']
+      if (opts['app-version']) {
+        rcOpts['product-version'] = rcOpts['file-version'] = opts['app-version']
       }
 
-      if (opts['app-version']) {
-        rcOpts['product-version'] = opts['app-version']
+      if (opts['build-version']) {
+        rcOpts['file-version'] = opts['build-version']
       }
 
       if (opts['app-copyright']) {


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Totes

**Summarize your changes:**

Default the `build-version` option to the `app-version` when it is unspecified. This makes the Windows behavior consistent with the macOS defaulting behavior introduced in  #449.

Closes #498 

**Are your changes appropriately documented?**

Yup

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes
