### PR TITLE
Update get-package-info

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,19 +83,23 @@ function getMetadata (opts, dir, cb) {
       opts['app-version'] = result.values.version
     }
 
-    if (result.values[`dependencies.electron`]) {
-      var packageName = result.source[`dependencies.electron`].prop.split('.')[1]
-      resolve(packageName, {
-        basedir: path.dirname(result.source[`dependencies.electron`].src)
-      }, function (err, res, pkg) {
-        if (err) return cb(err)
-        debug(`Inferring target Electron version from ${result.source['dependencies.electron'].prop} in ${result.source['dependencies.electron'].src}`)
-        opts.version = pkg.version
-        return cb(null)
-      })
+    if (result.values['dependencies.electron']) {
+      let {prop, src} = result.source['dependencies.electron']
+      return getVersion(opts, prop.split('.')[1], src, cb)
     } else {
       return cb(null)
     }
+  })
+}
+
+function getVersion (opts, packageName, src, cb) {
+  resolve(packageName, {
+    basedir: path.dirname(src)
+  }, (err, res, pkg) => {
+    if (err) return cb(err)
+    debug(`Inferring target Electron version from ${packageName} in ${src}`)
+    opts.version = pkg.version
+    return cb(null)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -67,8 +67,9 @@ function getMetadata (opts, dir, cb) {
     }
 
     if (result.values['dependencies.electron']) {
-      let {prop, src} = result.source['dependencies.electron']
-      return getVersion(opts, prop.split('.')[1], src, cb)
+      let prop = result.source['dependencies.electron'].prop.split('.')[1]
+      let src = result.source['dependencies.electron'].src
+      return getVersion(opts, prop, src, cb)
     } else {
       return cb(null)
     }

--- a/index.js
+++ b/index.js
@@ -23,50 +23,77 @@ function getMetadata (opts, dir, cb) {
   var props = []
   if (!opts.name) props.push(['productName', 'name'])
   if (!opts['app-version']) props.push('version')
-  if (!opts.version) props.push(['dependencies.electron', 'devDependencies.electron'])
+  if (!opts.version) {
+    props.push([
+      'dependencies.electron',
+      'devDependencies.electron',
+      'dependencies.electron-prebuilt',
+      'devDependencies.electron-prebuilt'
+    ])
+  }
 
   // Name and version provided, no need to infer
   if (props.length === 0) return cb(null)
 
   // Search package.json files to infer name and version from
-  getPackageInfo(props, dir, function (err, result) {
-    if (err) {
-      // `get-package-info` exploded looking for `electron`. Try `electron-prebuilt` instead
-      props.pop()
-      props.push(['dependencies.electron-prebuilt', 'devDependencies.electron-prebuilt'])
-      getPackageInfo(props, dir, function (err, result) {
+  getPackageInfo(props, dir, (err, result) => {
+    if (err && err.missingProps) {
+      var requiredProps = ['productName', 'dependencies.electron']
+      var missingProps = err.missingProps.map(prop => {
+        return Array.isArray(prop) ? prop[0] : prop
+      })
+
+      // Callback w/ error if there are required props that are missing
+      if (missingProps.filter(prop => requiredProps.find(reqProp => prop === reqProp)).length !== 0) {
+        var messages = missingProps.map(function (missingProp) {
+          missingProp = Array.isArray(missingProp) ? missingProp[0] : missingProp
+          if (missingProp === 'productName') {
+            return 'Unable to determine application name. Please specify an application name\n\n' +
+              'For more information, please see\n' +
+              'https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#name\n'
+          }
+
+          if (missingProp === 'dependencies.electron') {
+            return 'Unable to determine Electron version. Please specify an Electron version\n\n' +
+              'For more information, please see\n' +
+              'https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#version\n'
+          }
+        })
+
+        err.message = messages.join('\n') + '\n' + err.message
+        return cb(err)
+      } else {
+        // Missing props not required, can continue w/ partial result
+        result = err.result
+      }
+    } else if (err) {
+      return cb(err)
+    }
+
+    if (result.values.productName) {
+      debug('Inferring application name from productName or name in package.json')
+      opts.name = result.values.productName
+    }
+
+    if (result.values.version) {
+      debug('Inferring app-version from version in package.json')
+      opts['app-version'] = result.values.version
+    }
+
+    if (result.values[`dependencies.electron`]) {
+      var packageName = result.source[`dependencies.electron`].prop.split('.')[1]
+      resolve(packageName, {
+        basedir: path.dirname(result.source[`dependencies.electron`].src)
+      }, function (err, res, pkg) {
         if (err) return cb(err)
-        return inferNameAndVersionFromInstalled('electron-prebuilt', opts, result, cb)
+        debug(`Inferring target Electron version from ${packageName} dependency or devDependency in package.json`)
+        opts.version = pkg.version
+        return cb(null)
       })
     } else {
-      return inferNameAndVersionFromInstalled('electron', opts, result, cb)
+      return cb(null)
     }
   })
-}
-
-function inferNameAndVersionFromInstalled (packageName, opts, result, cb) {
-  if (result.values.productName) {
-    debug('Inferring application name from productName or name in package.json')
-    opts.name = result.values.productName
-  }
-
-  if (result.values.version) {
-    debug('Inferring app-version from version in package.json')
-    opts['app-version'] = result.values.version
-  }
-
-  if (result.values[`dependencies.${packageName}`]) {
-    resolve(packageName, {
-      basedir: path.dirname(result.source[`dependencies.${packageName}`].src)
-    }, function (err, res, pkg) {
-      if (err) return cb(err)
-      debug(`Inferring target Electron version from ${packageName} dependency or devDependency in package.json`)
-      opts.version = pkg.version
-      return cb(null)
-    })
-  } else {
-    return cb(null)
-  }
 }
 
 function createSeries (opts, archs, platforms) {
@@ -198,15 +225,7 @@ module.exports = function packager (opts, cb) {
   debug(`Target Architectures: ${archs.join(', ')}`)
 
   getMetadata(opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {
-    if (err) {
-      err.message = 'Unable to determine application name or Electron version. ' +
-        'Please specify an application name and Electron version.\n\n' +
-        'For more infomation, please see \n' +
-        'https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#name or \n' +
-        'https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#version\n\n' +
-        err.message
-      return cb(err)
-    }
+    if (err) return cb(err)
 
     debug(`Application name: ${opts.name}`)
     debug(`Target Electron version: ${opts.version}`)

--- a/index.js
+++ b/index.js
@@ -38,29 +38,12 @@ function getMetadata (opts, dir, cb) {
   // Search package.json files to infer name and version from
   getPackageInfo(props, dir, (err, result) => {
     if (err && err.missingProps) {
-      let requiredProps = ['productName', 'dependencies.electron']
       let missingProps = err.missingProps.map(prop => {
         return Array.isArray(prop) ? prop[0] : prop
       })
 
-      // Callback w/ error if there are required props that are missing
-      if (missingProps.filter(prop => requiredProps.find(reqProp => prop === reqProp)).length !== 0) {
-        let messages = missingProps.map(missingProp => {
-          let hash, propName
-          if (missingProp === 'productName') {
-            hash = 'name'
-            propName = 'application name'
-          }
-
-          if (missingProp === 'dependencies.electron') {
-            hash = 'version'
-            propName = 'Electron version'
-          }
-
-          return `Unable to determine ${propName}. Please specify an ${propName}\n\n` +
-            'For more information, please see\n' +
-            `https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#${hash}\n`
-        })
+      if (isMissingRequiredProperty(missingProps)) {
+        let messages = missingProps.map(errorMessageForProperty)
 
         debug(err.message)
         err.message = messages.join('\n') + '\n'
@@ -90,6 +73,30 @@ function getMetadata (opts, dir, cb) {
       return cb(null)
     }
   })
+}
+
+function isMissingRequiredProperty (props) {
+  var requiredProps = props.filter(
+    (prop) => prop === 'productName' || prop === 'dependencies.electron'
+  )
+  return requiredProps.length !== 0
+}
+
+function errorMessageForProperty (prop) {
+  let hash, propName
+  if (prop === 'productName') {
+    hash = 'name'
+    propName = 'application name'
+  }
+
+  if (prop === 'dependencies.electron') {
+    hash = 'version'
+    propName = 'Electron version'
+  }
+
+  return `Unable to determine ${propName}. Please specify an ${propName}\n\n` +
+    'For more information, please see\n' +
+    `https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#${hash}\n`
 }
 
 function getVersion (opts, packageName, src, cb) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "is-admin": "^2.0.0",
     "nyc": "^8.0.0",
+    "pkg-up": "^1.0.0",
     "rcinfo": "^0.1.3",
     "rimraf": "^2.3.2",
     "run-waterfall": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "electron-osx-sign": "^0.3.0",
     "extract-zip": "^1.0.3",
     "fs-extra": "^0.30.0",
-    "get-package-info": "^0.1.0",
+    "get-package-info": "^1.0.0",
     "minimist": "^1.1.1",
     "plist": "^2.0.0",
     "rcedit": "^0.7.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -301,7 +301,7 @@ function createInferFailureTest (opts, fixtureSubdir) {
 }
 
 function createInferMissingVersionTest (opts) {
-  return function (t) {
+  return (t) => {
     t.timeoutAfter(config.timeout)
     copyFixtureToTempDir('infer-missing-version-only', (err, dir) => {
       if (err) return t.end(err)
@@ -310,7 +310,7 @@ function createInferMissingVersionTest (opts) {
       opts.dir = dir
       let packageJSON = require(path.join(opts.dir, 'package.json'))
 
-      packager(opts, function (err, paths) {
+      packager(opts, (err, paths) => {
         if (!err) {
           var version = fs.readFileSync(path.join(paths[0], 'version'), 'utf8')
           t.equal(`v${packageJSON.devDependencies['electron']}`, version.toString(), 'The version should be inferred from installed `electron` version')
@@ -328,6 +328,10 @@ function createInferMissingFieldsTest (opts) {
 
 function createInferWithBadFieldsTest (opts) {
   return createInferFailureTest(opts, 'infer-bad-fields')
+}
+
+function createInferWithMalformedJSONTest (opts) {
+  return createInferFailureTest(opts, 'infer-malformed-json')
 }
 
 function createTmpdirTest (opts) {
@@ -449,6 +453,7 @@ util.testSinglePlatform('infer test using `electron-prebuilt` package', createIn
 util.testSinglePlatform('infer test using `electron` package', createInferElectronTest)
 util.testSinglePlatform('infer missing fields test', createInferMissingFieldsTest)
 util.testSinglePlatform('infer with bad fields test', createInferWithBadFieldsTest)
+util.testSinglePlatform('infer with malformed JSON test', createInferWithMalformedJSONTest)
 util.testSinglePlatform('infer with missing version only test', createInferMissingVersionTest)
 util.testSinglePlatform('defaults test', createDefaultsTest)
 util.testSinglePlatform('out test', createOutTest)

--- a/test/basic.js
+++ b/test/basic.js
@@ -294,6 +294,28 @@ function createInferFailureTest (opts, fixtureSubdir) {
   }
 }
 
+function createInferMissingVersionTest (opts) {
+  return function (t) {
+    t.timeoutAfter(config.timeout)
+    copyFixtureToTempDir('infer-missing-version-only', (err, dir) => {
+      if (err) return t.end(err)
+
+      delete opts.version
+      opts.dir = dir
+      let packageJSON = require(path.join(opts.dir, 'package.json'))
+
+      packager(opts, function (err, paths) {
+        if (!err) {
+          var version = fs.readFileSync(path.join(paths[0], 'version'), 'utf8')
+          t.equal(`v${packageJSON.devDependencies['electron']}`, version.toString(), 'The version should be inferred from installed `electron` version')
+        }
+
+        t.end(err)
+      })
+    })
+  }
+}
+
 function createInferMissingFieldsTest (opts) {
   return createInferFailureTest(opts, 'infer-missing-fields')
 }
@@ -421,6 +443,7 @@ util.testSinglePlatform('infer test using `electron-prebuilt` package', createIn
 util.testSinglePlatform('infer test using `electron` package', createInferElectronTest)
 util.testSinglePlatform('infer missing fields test', createInferMissingFieldsTest)
 util.testSinglePlatform('infer with bad fields test', createInferWithBadFieldsTest)
+util.testSinglePlatform('infer with missing version only test', createInferMissingVersionTest)
 util.testSinglePlatform('defaults test', createDefaultsTest)
 util.testSinglePlatform('out test', createOutTest)
 util.testSinglePlatform('prune test', (baseOpts) => {

--- a/test/basic.js
+++ b/test/basic.js
@@ -9,6 +9,7 @@ const path = require('path')
 const test = require('tape')
 const util = require('./util')
 const waterfall = require('run-waterfall')
+const pkgUp = require('pkg-up')
 
 // Generates a path to the generated app that reflects the name given in the options.
 // Returns the Helper.app location on darwin since the top-level .app is already tested for the
@@ -270,6 +271,11 @@ function copyFixtureToTempDir (fixtureSubdir, cb) {
   let tmpdir = path.join(os.tmpdir(), fixtureSubdir)
   let fixtureDir = path.join(__dirname, 'fixtures', fixtureSubdir)
   waterfall([
+    cb => {
+      let tmpdirPkg = pkgUp.sync(path.join(tmpdir, '..'))
+      if (tmpdirPkg) return cb(new Error(`Found package.json in parent of temp directory, which will interfere with test results. Please remove package.json at ${tmpdirPkg}`))
+      cb()
+    },
     cb => fs.emptyDir(tmpdir, cb),
     (cb1, cb2) => fs.copy(fixtureDir, tmpdir, cb2 || cb1), // inconsistent cb arguments from fs.emptyDir
     cb => cb(null, tmpdir)

--- a/test/basic.js
+++ b/test/basic.js
@@ -271,7 +271,7 @@ function copyFixtureToTempDir (fixtureSubdir, cb) {
   let fixtureDir = path.join(__dirname, 'fixtures', fixtureSubdir)
   waterfall([
     cb => fs.emptyDir(tmpdir, cb),
-    cb => fs.copy(fixtureDir, tmpdir, cb),
+    (cb1, cb2) => fs.copy(fixtureDir, tmpdir, cb2 || cb1), // inconsistent cb arguments from fs.emptyDir
     cb => cb(null, tmpdir)
   ], cb)
 }

--- a/test/fixtures/infer-malformed-json/package.json
+++ b/test/fixtures/infer-malformed-json/package.json
@@ -1,0 +1,2 @@
+{
+  "productName": "InferMalformedJSON",

--- a/test/fixtures/infer-missing-version-only/package.json
+++ b/test/fixtures/infer-missing-version-only/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "main.js",
+  "productName": "MainJS",
+  "devDependencies": {
+    "electron": "1.3.1"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,7 @@ function npmInstallforFixtures () {
   const fixtures = [
     'basic',
     'basic-renamed-to-electron',
+    'infer-missing-version-only',
     'el-0374'
   ]
   return fixtures.map((fixture) => {


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?** Yes



**Summarize your changes:**

As discussed in #461, this updates `get-package-info` to v1.0.0, which includes more helpful errors when failing to find all info requested. This lets us give better error messages, as well as ignore missing props for optional options.

**Are your changes appropriately documented?** N/A



**Do your changes have sufficient test coverage?** Not sure yet.



**Does the testsuite pass successfully on your local machine?** Yes



