### PR TITLE
fix typo in extend-info and add support object params

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -233,9 +233,13 @@ Valid values are listed in [Apple's documentation](https://developer.apple.com/l
 
 ##### `extend-info`
 
-*String*
+*String* or *Object*
 
-Filename of a plist file; the contents are added to the app's plist. Entries in `extend-info` override entries in the base plist file supplied by `electron` or `electron-prebuilt`, but are overridden by other explicit arguments such as [`app-version`](#app-version) or [`app-bundle-id`](#app-bundle-id).
+When the value is a `String`, the filename of a plist file. Its contents are added to the app's plist. When the value is an `Object`, an already-parsed plist data structure that is merged into the app's plist.
+
+Entries from `extend-info` override entries in the base plist file supplied by `electron` or `electron-prebuilt`, but are overridden by other explicit arguments such as [`app-version`](#app-version) or [`app-bundle-id`](#app-bundle-id).
+
+
 
 ##### `extra-resource`
 

--- a/mac.js
+++ b/mac.js
@@ -98,7 +98,7 @@ class MacApp {
     this.helperBundleIdentifier = filterCFBundleIdentifier(this.opts['helper-bundle-id'] || `${appBundleIdentifier}.helper`)
 
     if (this.opts['extend-info']) {
-      this.appPlis = this.extendAppPlist(this.opts['extend-info'])
+      this.appPlist = this.extendAppPlist(this.opts['extend-info'])
     }
 
     this.appPlist = this.updatePlist(this.appPlist, this.appName, appBundleIdentifier, this.appName)

--- a/mac.js
+++ b/mac.js
@@ -69,8 +69,13 @@ class MacApp {
     return this.updatePlist(base, `${this.appName} ${helperSuffix}`, identifier, name)
   }
 
-  extendAppPlist (filename) {
-    let extendedAppPlist = plist.parse(fs.readFileSync(filename).toString())
+  extendAppPlist (props) {
+    let extendedAppPlist = props
+
+    if (typeof props === 'string') {
+      extendedAppPlist = plist.parse(fs.readFileSync(props).toString())
+    }
+
     return Object.assign(this.appPlist, extendedAppPlist)
   }
 

--- a/test/mac.js
+++ b/test/mac.js
@@ -158,12 +158,12 @@ function createExtraResource2Test (baseOpts) {
   }
 }
 
-function createExtendInfoTest (baseOpts, extraPath) {
+function createExtendInfoTest (baseOpts, extraPathOrParams) {
   return function (t) {
     t.timeoutAfter(config.timeout)
 
     var opts = Object.create(baseOpts)
-    opts['extend-info'] = extraPath
+    opts['extend-info'] = extraPathOrParams
     opts['build-version'] = '3.2.1'
     opts['app-bundle-id'] = 'com.electron.extratest'
     opts['app-category-type'] = 'public.app-category.music'
@@ -532,6 +532,7 @@ module.exports = (baseOpts) => {
     platform: 'darwin'
   }
   let extraInfoPath = path.join(__dirname, 'fixtures', 'extrainfo.plist')
+  let extraInfoParams = plist.parse(fs.readFileSync(extraInfoPath).toString())
 
   util.packagerTest('helper app paths test', createHelperAppPathsTest(baseOpts))
   util.packagerTest('helper app paths test with app name needing sanitization', createHelperAppPathsTest(Object.assign({}, baseOpts, {name: '@username/package-name'}), '@username-package-name'))
@@ -541,7 +542,8 @@ module.exports = (baseOpts) => {
   util.packagerTest('icon test: .ico specified (should replace with .icns)', createIconTest(baseOpts, iconBase + '.ico', icnsPath))
   util.packagerTest('icon test: basename only (should add .icns)', createIconTest(baseOpts, iconBase, icnsPath))
 
-  util.packagerTest('extend-info test', createExtendInfoTest(baseOpts, extraInfoPath))
+  util.packagerTest('extend-info by filename test', createExtendInfoTest(baseOpts, extraInfoPath))
+  util.packagerTest('extend-info by params test', createExtendInfoTest(baseOpts, extraInfoParams))
 
   util.packagerTest('extra-resource test: one arg', createExtraResourceTest(baseOpts))
   util.packagerTest('extra-resource test: two arg', createExtraResource2Test(baseOpts))

--- a/usage.txt
+++ b/usage.txt
@@ -60,7 +60,7 @@ app-bundle-id      bundle identifier to use in the app plist
 app-category-type  the application category type
                    For example, `app-category-type=public.app-category.developer-tools` will set the
                    application category to 'Developer Tools'.
-extend-info        a plist file to append to the app plist
+extend-info        a plist file to merge into the app plist
 extra-resource     a file to copy into the app's Contents/Resources
 helper-bundle-id   bundle identifier to use in the app helper plist
 osx-sign           (OSX host platform only) Whether to sign the OSX app packages. You can either


### PR DESCRIPTION
**Summarize your changes:**
fix typo in extend plist
added object params support for the "extend-info"

```
packager({
  ...
  'extend-info': {
     ElectronTeamId: 'RJ883jd299'
   }
});
```


**Are your changes appropriately documented?**
no, My English is not enough for writing docs


**Do your changes have sufficient test coverage?**
yes


**Does the testsuite pass successfully on your local machine?**
yes


