### PR TITLE
Fix sign task to propagate error back up

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -212,7 +212,7 @@ class MacApp {
             // Although not signed successfully, the application is packed.
             console.warn('Code sign failed; please retry manually.', err)
           }
-          cb()
+          cb(err)
         })
       })
     }


### PR DESCRIPTION
When the codesign fails due to an error like `Error: No identity found for signing`, not propagating the error will not notify the remaining dependent tasks. The builds were being marked as done with no errors, even when codesign failed.