### PR TITLE
Add quiet option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* `quiet` option (#541)
+
 ## [8.3.0] - 2016-11-16
 
 ### Changed

--- a/common.js
+++ b/common.js
@@ -23,7 +23,8 @@ function parseCLIArgs (argv) {
       'deref-symlinks',
       'download.strictSSL',
       'overwrite',
-      'prune'
+      'prune',
+      'quiet'
     ],
     default: {
       'deref-symlinks': true,
@@ -99,9 +100,21 @@ function generateFinalPath (opts) {
   return path.join(opts.out || process.cwd(), generateFinalBasename(opts))
 }
 
-function subOptionWarning (properties, optionName, parameter, value) {
+function info (message, quiet) {
+  if (!quiet) {
+    console.error(message)
+  }
+}
+
+function warning (message, quiet) {
+  if (!quiet) {
+    console.warn(message)
+  }
+}
+
+function subOptionWarning (properties, optionName, parameter, value, quiet) {
   if (properties.hasOwnProperty(parameter)) {
-    console.warn(`WARNING: ${optionName}.${parameter} will be inferred from the main options`)
+    warning(`WARNING: ${optionName}.${parameter} will be inferred from the main options`, quiet)
   }
   properties[parameter] = value
 }
@@ -115,7 +128,7 @@ function createAsarOpts (opts) {
   } else if (opts.asar === false || opts.asar === undefined) {
     return false
   } else {
-    console.warn(`asar parameter set to an invalid value (${opts.asar}), ignoring and disabling asar`)
+    warning(`asar parameter set to an invalid value (${opts.asar}), ignoring and disabling asar`)
     return false
   }
 
@@ -125,9 +138,9 @@ function createAsarOpts (opts) {
 function createDownloadOpts (opts, platform, arch) {
   let downloadOpts = Object.assign({}, opts.download)
 
-  subOptionWarning(downloadOpts, 'download', 'platform', platform)
-  subOptionWarning(downloadOpts, 'download', 'arch', arch)
-  subOptionWarning(downloadOpts, 'download', 'version', opts.version)
+  subOptionWarning(downloadOpts, 'download', 'platform', platform, opts.quiet)
+  subOptionWarning(downloadOpts, 'download', 'arch', arch, opts.quiet)
+  subOptionWarning(downloadOpts, 'download', 'version', opts.version, opts.quiet)
 
   return downloadOpts
 }
@@ -172,6 +185,8 @@ module.exports = {
 
   generateFinalBasename: generateFinalBasename,
   generateFinalPath: generateFinalPath,
+
+  info: info,
 
   initializeApp: function initializeApp (opts, templatePath, appRelativePath, callback) {
     // Performs the following initial operations for an app:
@@ -284,5 +299,6 @@ module.exports = {
     debug(`Renaming ${oldName} to ${newName} in ${basePath}`)
     fs.rename(path.join(basePath, oldName), path.join(basePath, newName), cb)
   },
-  sanitizeAppName: sanitizeAppName
+  sanitizeAppName: sanitizeAppName,
+  warning: warning
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -200,6 +200,13 @@ The non-`all` values correspond to the platform names used by [Electron releases
 
 Runs [`npm prune --production`](https://docs.npmjs.com/cli/prune) before starting to package the app.
 
+##### `quiet`
+
+*Boolean* (default: `false`)
+
+If `true`, disables printing informational and warning messages to the console when packaging the
+application. This does *not* disable errors.
+
 ##### `tmpdir`
 
 *String* or *`false`* (default: system temp directory)

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function createSeries (opts, archs, platforms) {
             buildParentDir = opts.out || process.cwd()
           }
           var buildDir = path.join(buildParentDir, `${platform}-${arch}-template`)
-          console.error(`Packaging app for platform ${platform} ${arch} using electron v${version}`)
+          common.info(`Packaging app for platform ${platform} ${arch} using electron v${version}`, opts.quiet)
           series([
             function (cb) {
               debug(`Creating ${buildDir}`)
@@ -203,7 +203,7 @@ function createSeries (opts, archs, platforms) {
                   createApp(comboOpts)
                 })
               } else {
-                console.error(`Skipping ${platform} ${arch} (output dir already exists, use --overwrite to force)`)
+                common.info(`Skipping ${platform} ${arch} (output dir already exists, use --overwrite to force)`, opts.quiet)
                 callback()
               }
             } else {
@@ -216,7 +216,7 @@ function createSeries (opts, archs, platforms) {
           testSymlink(function (result) {
             if (result) return checkOverwrite()
 
-            console.error(`Cannot create symlinks (on Windows hosts, it requires admin privileges); skipping ${combination.platform} platform`)
+            common.info(`Cannot create symlinks (on Windows hosts, it requires admin privileges); skipping ${combination.platform} platform`, opts.quiet)
             callback()
           })
         } else {

--- a/mac.js
+++ b/mac.js
@@ -199,18 +199,18 @@ class MacApp {
 
     if ((platform === 'all' || platform === 'mas') &&
         osxSignOpt === undefined) {
-      console.warn('WARNING: signing is required for mas builds. Provide the osx-sign option, ' +
-                   'or manually sign the app later.')
+      common.warning('WARNING: signing is required for mas builds. Provide the osx-sign option, ' +
+                     'or manually sign the app later.')
     }
 
     if (osxSignOpt) {
       this.operations.push((cb) => {
-        let signOpts = createSignOpts(osxSignOpt, platform, this.renamedAppPath, version)
+        let signOpts = createSignOpts(osxSignOpt, platform, this.renamedAppPath, version, this.opts.quiet)
         debug(`Running electron-osx-sign with the options ${JSON.stringify(signOpts)}`)
         sign(signOpts, (err) => {
           if (err) {
             // Although not signed successfully, the application is packed.
-            console.warn('Code sign failed; please retry manually.', err)
+            common.warning('Code sign failed; please retry manually.', err)
           }
           cb()
         })
@@ -233,19 +233,19 @@ function filterCFBundleIdentifier (identifier) {
   return identifier.replace(/ /g, '-').replace(/[^a-zA-Z0-9.-]/g, '')
 }
 
-function createSignOpts (properties, platform, app, version) {
+function createSignOpts (properties, platform, app, version, quiet) {
   // use default sign opts if osx-sign is true, otherwise clone osx-sign object
   let signOpts = properties === true ? {identity: null} : Object.assign({}, properties)
 
   // osx-sign options are handed off to sign module, but
   // with a few additions from the main options
   // user may think they can pass platform, app, or version, but they will be ignored
-  common.subOptionWarning(signOpts, 'osx-sign', 'platform', platform)
-  common.subOptionWarning(signOpts, 'osx-sign', 'app', app)
-  common.subOptionWarning(signOpts, 'osx-sign', 'version', version)
+  common.subOptionWarning(signOpts, 'osx-sign', 'platform', platform, quiet)
+  common.subOptionWarning(signOpts, 'osx-sign', 'app', app, quiet)
+  common.subOptionWarning(signOpts, 'osx-sign', 'version', version, quiet)
 
   if (signOpts.binaries) {
-    console.warn('WARNING: osx-sign.binaries is not an allowed sub-option. Not passing to electron-osx-sign.')
+    common.warning('WARNING: osx-sign.binaries is not an allowed sub-option. Not passing to electron-osx-sign.')
     delete signOpts.binaries
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -427,9 +427,9 @@ test('validateListFromOptions does not take non-Array/String values', (t) => {
 })
 
 test('setting the quiet option does not print messages', (t) => {
-  const error_log = console.error
-  const warning_log = console.warn
-  let output = '';
+  const errorLog = console.error
+  const warningLog = console.warn
+  let output = ''
   console.error = (message) => { output += message }
   console.warn = (message) => { output += message }
 
@@ -438,8 +438,8 @@ test('setting the quiet option does not print messages', (t) => {
   common.info('info', true)
   t.equal('', output, 'quieted common.info should not call console.error')
 
-  console.error = error_log
-  console.warn = warning_log
+  console.error = errorLog
+  console.warn = warningLog
   t.end()
 })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -426,6 +426,23 @@ test('validateListFromOptions does not take non-Array/String values', (t) => {
   t.end()
 })
 
+test('setting the quiet option does not print messages', (t) => {
+  const error_log = console.error
+  const warning_log = console.warn
+  let output = '';
+  console.error = (message) => { output += message }
+  console.warn = (message) => { output += message }
+
+  common.warning('warning', true)
+  t.equal('', output, 'quieted common.warning should not call console.warn')
+  common.info('info', true)
+  t.equal('', output, 'quieted common.info should not call console.error')
+
+  console.error = error_log
+  console.warn = warning_log
+  t.end()
+})
+
 test('download argument test: download.{arch,platform,version} does not overwrite {arch,platform,version}', function (t) {
   var opts = {
     download: {

--- a/usage.txt
+++ b/usage.txt
@@ -50,6 +50,7 @@ overwrite          if output directory for a platform already exists, replaces i
                    skipping it
 platform           all, or one or more of: darwin, linux, mas, win32 (comma-delimited if multiple).
                    Defaults to the host platform
+quiet              Do not print informational or warning messages
 tmpdir             temp directory. Defaults to system temp directory, use --tmpdir=false to disable
                    use of a temporary directory.
 version            the version of Electron that is being packaged, see


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Summarize your changes:**

When set, this prevents printing Electron Packager specific warnings and informational messages to the console. This does *not* disable errors.

CC: @MarshallOfSound mostly because we can get rid of that console monkeypatch workaround in [Electron Forge](https://github.com/MarshallOfSound/electron-forge).

Fixes #538.

**Are your changes appropriately documented?**

Yes (CLI usage, API docs).

**Do your changes have sufficient test coverage?**

Yes.

**Does the testsuite pass successfully on your local machine?**

Yes.