### PR TITLE
Add an online documentation site with GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ This will:
 
 For an overview of the other optional flags, run `electron-packager --help` or see
 [usage.txt](https://github.com/electron-userland/electron-packager/blob/master/usage.txt). For
-detailed descriptions, see the [API documentation](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md).
+detailed descriptions, see the [API documentation](https://electron-userland.github.io/electron-packager/api).
 
 If `appname` is omitted, this will use the name specified by "productName" or "name" in the nearest package.json.
 


### PR DESCRIPTION
- [x] I have read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests).

**Summarize your changes:**
This PR adds a GitHub pages site that displays the documentation.
Currently, there is no documentation index, so it redirects to `/api`.

See [the live demo](https://j-f1.github.io/electron-packager).

**Are your changes appropriately documented?**
**Do your changes have sufficient test coverage?**
**Does the testsuite pass successfully on your local machine?**
N/A

**TODO**

- [ ] Enable GitHub Pages
- [ ] Choose an appropriate Jekyll theme (anything that isn’t [listed here](https://pages.github.com/themes) needs further exploration)
- [x] Include the API docs
- [x] Link to the API docs from the README
- [x] Symlink the README to `docs/index.md`
- [ ] Squash Commits