### PR TITLE
[RFC] Mention the community CoC & update issue/PR templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to electron-packager
+# Contributing to Electron Packager
 
-electron-packager is a community-driven project. As such, we welcome and encourage all sorts of
+Electron Packager is a community-driven project. As such, we welcome and encourage all sorts of
 contributions. They include, but are not limited to:
 
 - Constructive feedback
-- Questions about usage
+- [Questions about usage](#questions-about-usage)
 - [Bug reports / technical issues](#before-opening-bug-reportstechnical-issues)
 - Documentation changes
 - Feature requests
@@ -13,6 +13,14 @@ contributions. They include, but are not limited to:
 We strongly suggest that before filing an issue, you search through the existing issues to see
 if it has already been filed by someone else.
 
+This project is a part of the Electron ecosystem. As such, all contributions to this project follow
+[Electron's code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
+where appropriate.
+
+## Questions about usage
+
+If you have questions about usage, we encourage you to visit one of the several [community-driven
+sites](https://github.com/electron/electron#community).
 
 ## Before opening bug reports/technical issues
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,3 +1,8 @@
+<!--
+Thanks for filing an issue!
+Please check off all of the steps as they are completed by replacing [ ] with [x].
+-->
+
 * [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
 * [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
 * [ ] I have searched the issue tracker for an issue that matches the one I want to file, without success.

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,3 +1,7 @@
+* [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
+* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
+* [ ] I have searched the issue tracker for an issue that matches the one I want to file, without success.
+
 **Please describe your issue:**
 
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,19 +1,8 @@
-**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests)?**
-
-
+* [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
+* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
+* [ ] The changes are appropriately documented (if applicable).
+* [ ] The changes have sufficient test coverage (if applicable).
+* [ ] The testsuite passes successfully on my local machine (if applicable).
 
 **Summarize your changes:**
-
-
-
-**Are your changes appropriately documented?**
-
-
-
-**Do your changes have sufficient test coverage?**
-
-
-
-**Does the testsuite pass successfully on your local machine?**
-
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,8 @@
+<!--
+Thanks for filing a pull request!
+Please check off all of the steps as they are completed by replacing [ ] with [x].
+-->
+
 * [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
 * [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
 * [ ] The changes are appropriately documented (if applicable).


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

* Explicitly mention the community Code of Conduct. This has been implied since we're part of the Electron ecosystem, but I'd rather make it explicit.
* Add a section to the contributing docs about the Electron community forums.
* Update the issue/PR templates to mention the CoC and also use checkboxes.