### PR TITLE
Prepend all warning messages with 'WARNING:'

### DIFF
--- a/common.js
+++ b/common.js
@@ -113,13 +113,13 @@ function info (message, quiet) {
 
 function warning (message, quiet) {
   if (!quiet) {
-    console.warn(message)
+    console.warn(`WARNING: ${message}`)
   }
 }
 
 function subOptionWarning (properties, optionName, parameter, value, quiet) {
   if (properties.hasOwnProperty(parameter)) {
-    warning(`WARNING: ${optionName}.${parameter} will be inferred from the main options`, quiet)
+    warning(`${optionName}.${parameter} will be inferred from the main options`, quiet)
   }
   properties[parameter] = value
 }

--- a/mac.js
+++ b/mac.js
@@ -199,7 +199,7 @@ class MacApp {
 
     if ((platform === 'all' || platform === 'mas') &&
         osxSignOpt === undefined) {
-      common.warning('WARNING: signing is required for mas builds. Provide the osx-sign option, ' +
+      common.warning('signing is required for mas builds. Provide the osx-sign option, ' +
                      'or manually sign the app later.')
     }
 
@@ -245,7 +245,7 @@ function createSignOpts (properties, platform, app, version, quiet) {
   common.subOptionWarning(signOpts, 'osx-sign', 'version', version, quiet)
 
   if (signOpts.binaries) {
-    common.warning('WARNING: osx-sign.binaries is not an allowed sub-option. Not passing to electron-osx-sign.')
+    common.warning('osx-sign.binaries is not an allowed sub-option. Not passing to electron-osx-sign.')
     delete signOpts.binaries
   }
 


### PR DESCRIPTION
* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

Make it way more obvious that warning messages are not error messages. (see: #586 & duplicates)