### PR TITLE
Ignore the generated temporary directory on Linux

### DIFF
--- a/common.js
+++ b/common.js
@@ -124,6 +124,10 @@ function subOptionWarning (properties, optionName, parameter, value, quiet) {
   properties[parameter] = value
 }
 
+function baseTempDir (opts) {
+  return path.join(opts.tmpdir || os.tmpdir(), 'electron-packager')
+}
+
 function createAsarOpts (opts) {
   let asarOptions
   if (opts.asar === true) {
@@ -159,6 +163,8 @@ module.exports = {
   isPlatformMac: isPlatformMac,
 
   subOptionWarning: subOptionWarning,
+
+  baseTempDir: baseTempDir,
 
   createAsarOpts: createAsarOpts,
   createDownloadOpts: createDownloadOpts,
@@ -215,7 +221,7 @@ module.exports = {
     if (opts.tmpdir === false) {
       tempPath = generateFinalPath(opts)
     } else {
-      tempPath = path.join(opts.tmpdir || os.tmpdir(), 'electron-packager', `${opts.platform}-${opts.arch}`, generateFinalBasename(opts))
+      tempPath = path.join(baseTempDir(opts), `${opts.platform}-${opts.arch}`, generateFinalBasename(opts))
     }
 
     debug(`Initializing app in ${tempPath} from ${templatePath} template`)

--- a/docs/api.md
+++ b/docs/api.md
@@ -154,6 +154,7 @@ The following paths are always ignored (*when you aren't using the predicate fun
 described after the list*):
 
 * the directory specified by the [`out`](#out) parameter
+* the temporary directory used to build the Electron app
 * `node_modules/.bin`
 * `node_modules/electron`
 * `node_modules/electron-prebuilt`

--- a/ignore.js
+++ b/ignore.js
@@ -18,7 +18,7 @@ function generateIgnores (opts) {
     const common = require('./common')
 
     if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
-    opts.ignore = (opts.ignore) ? opts.ignore.concat(DEFAULT_IGNORES) : DEFAULT_IGNORES
+    opts.ignore = (opts.ignore) ? opts.ignore.concat(DEFAULT_IGNORES) : [].concat(DEFAULT_IGNORES)
     if (process.platform === 'linux') {
       opts.ignore.push(common.baseTempDir(opts))
     }

--- a/ignore.js
+++ b/ignore.js
@@ -14,8 +14,14 @@ const DEFAULT_IGNORES = [
 
 function generateIgnores (opts) {
   if (typeof (opts.ignore) !== 'function') {
+    // Avoid a circular require that breaks things
+    const common = require('./common')
+
     if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
     opts.ignore = (opts.ignore) ? opts.ignore.concat(DEFAULT_IGNORES) : DEFAULT_IGNORES
+    if (process.platform === 'linux') {
+      opts.ignore.push(common.baseTempDir(opts))
+    }
 
     debug('Ignored path regular expressions:', opts.ignore)
   }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const fs = require('fs-extra')
 const getPackageInfo = require('get-package-info')
 const ignore = require('./ignore')
 const metadata = require('./package.json')
-const os = require('os')
 const path = require('path')
 const resolve = require('resolve')
 const series = require('run-series')
@@ -112,7 +111,7 @@ function getVersion (opts, packageName, src, cb) {
 }
 
 function createSeries (opts, archs, platforms) {
-  var tempBase = path.join(opts.tmpdir || os.tmpdir(), 'electron-packager')
+  const tempBase = common.baseTempDir(opts)
 
   function testSymlink (cb) {
     var testPath = path.join(tempBase, 'symlink-test')

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -142,6 +142,7 @@ test('generateIgnores ignores the generated temporary directory only on Linux', 
 
   ignore.generateIgnores(opts)
 
+  // Array.prototype.includes is added (not behind a feature flag) in Node 6
   if (process.platform === 'linux') {
     t.notOk(opts.ignore.indexOf(expected) === -1, 'temporary dir in opts.ignore')
   } else {

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -135,6 +135,22 @@ function createIgnoreImplicitOutDirTest (opts) {
   }
 }
 
+test('generateIgnores ignores the generated temporary directory only on Linux', (t) => {
+  const tmpdir = '/foo/bar'
+  const expected = path.join(tmpdir, 'electron-packager')
+  let opts = {tmpdir}
+
+  ignore.generateIgnores(opts)
+
+  if (process.platform === 'linux') {
+    t.notOk(opts.ignore.indexOf(expected) === -1, 'temporary dir in opts.ignore')
+  } else {
+    t.ok(opts.ignore.indexOf(expected) === -1, 'temporary dir not in opts.ignore')
+  }
+
+  t.end()
+})
+
 test('generateOutIgnores ignores all possible platform/arch permutations', (t) => {
   let ignores = ignore.generateOutIgnores({name: 'test'})
   t.equal(ignores.length, common.platforms.length * common.archs.length)

--- a/test/util.js
+++ b/test/util.js
@@ -86,6 +86,7 @@ exports.packagerTest = function packagerTest (name, testFunction) {
   exports.teardown()
 }
 
+// Rest parameters are added (not behind a feature flag) in Node 6
 exports.testSinglePlatform = function testSinglePlatform (name, createTest /*, ...createTestArgs */) {
   var args = slice.call(arguments, 2)
   exports.packagerTest(name, createTest.apply(null, [{platform: 'linux', arch: 'x64', electronVersion: config.version}].concat(args)))


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* [X] The changes have sufficient test coverage (if applicable).
* [X] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #548. (The weird Docker bug.)

Also, put the building of the temporary directory path into its own function.

CC: @MarshallOfSound 