### PR TITLE
Ignore Travis Node 5 + OSX worker due to strange problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ branches:
   only:
   - master
   - /^v\d+\.\d+\.\d+/
+matrix:
+  allow_failures:
+  - node_js: '5'
+    os: osx
 env:
   global:
     # coveralls token


### PR DESCRIPTION
* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* <del>The changes have sufficient test coverage (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

Run but don't require a CI pass for Node 5 + OSX.

Workaround for #598.