### PR TITLE
Infer platform/arch in readme instead of using --all

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ default. You can use `--ignore` to ignore files and folders via a regular expres
 
 #### Example
 
-Let's assume that you have made an app based on the [electron-quick-start](https://github.com/electron/electron-quick-start) repository on a OS X or Linux host platform with the following file structure:
+Let's assume that you have made an app based on the [electron-quick-start](https://github.com/electron/electron-quick-start) repository on a OS X host platform with the following file structure:
 
 ```
 foobar
@@ -114,12 +114,13 @@ foobar
 
 * `electron-packager` is installed globally
 * `productName` in `package.json` has been set to `Foo Bar`
+* The `electron` module is in the `devDependencies` section of `package.json`, and set to the exact version of `1.4.15`.
 * `npm install` for the `Foo Bar` app has been run at least once
 
 When one runs the following command for the first time in the `foobar` directory:
 
 ```
-electron-packager . --all
+electron-packager .
 ```
 
 `electron-packager` will do the following:
@@ -127,11 +128,10 @@ electron-packager . --all
 * Use the current directory for the `sourcedir`
 * Infer the `appname` from the `productName` in `package.json`
 * Infer the `app-version` from the `version` in `package.json`
-* Download [all supported target platforms and arches](#supported-platforms) of Electron
-using the installed `electron` or `electron-prebuilt` version (and cache the downloads in `~/.electron`)
-* For the `darwin` build, as an example:
-  * build the OS X `Foo Bar.app`
-  * place `Foo Bar.app` in `foobar/Foo Bar-darwin-x64/` (since an `out` directory was not specified, it used the current working directory)
+* Infer the `platform` and `arch` from the host, in this example, `darwin` platform and `x64` arch.
+* Download the darwin x64 build of Electron 1.4.15 (and cache the downloads in `~/.electron`)
+* Build the OS X `Foo Bar.app`
+* Place `Foo Bar.app` in `foobar/Foo Bar-darwin-x64/` (since an `out` directory was not specified, it used the current working directory)
 
 The file structure now looks like:
 


### PR DESCRIPTION
* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

This changes the default recommendation to use Packager to build bundles for a given target platform on the same host platform.