### PR TITLE
Always return an Error or null in node-style callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ module.exports = function packager (opts, cb) {
     if (err) return cb(err)
 
     if (/ Helper$/.test(opts.name)) {
-      return cb('Application names cannot end in " Helper" due to limitations on macOS')
+      return cb(new Error('Application names cannot end in " Helper" due to limitations on macOS'))
     }
 
     debug(`Application name: ${opts.name}`)

--- a/test/basic.js
+++ b/test/basic.js
@@ -495,7 +495,7 @@ test('cannot build apps where the name ends in " Helper"', (t) => {
   }
 
   packager(opts, (err) => {
-    t.equal('Application names cannot end in " Helper" due to limitations on macOS', err)
+    t.equal('Application names cannot end in " Helper" due to limitations on macOS', err.message)
     t.end()
   })
 })


### PR DESCRIPTION
This will be a style error in the next version of standard (v10).