### PR TITLE
Limited support for inferring electron-prebuilt-compile

### DIFF
--- a/common.js
+++ b/common.js
@@ -5,10 +5,12 @@ const child = require('child_process')
 const debug = require('debug')('electron-packager')
 const download = require('electron-download')
 const fs = require('fs-extra')
+const getPackageInfo = require('get-package-info')
 const ignore = require('./ignore')
 const minimist = require('minimist')
 const os = require('os')
 const path = require('path')
+const resolve = require('resolve')
 const sanitize = require('sanitize-filename')
 const semver = require('semver')
 const series = require('run-series')
@@ -153,6 +155,41 @@ function createDownloadOpts (opts, platform, arch) {
   return downloadOpts
 }
 
+function isMissingRequiredProperty (props) {
+  var requiredProps = props.filter(
+    (prop) => prop === 'productName' || prop === 'dependencies.electron'
+  )
+  return requiredProps.length !== 0
+}
+
+function errorMessageForProperty (prop) {
+  let hash, propName
+  if (prop === 'productName') {
+    hash = 'name'
+    propName = 'application name'
+  }
+
+  if (prop === 'dependencies.electron') {
+    hash = 'version'
+    propName = 'Electron version'
+  }
+
+  return `Unable to determine ${propName}. Please specify an ${propName}\n\n` +
+    'For more information, please see\n' +
+    `https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#${hash}\n`
+}
+
+function getVersion (opts, packageName, src, cb) {
+  resolve(packageName, {
+    basedir: path.dirname(src)
+  }, (err, res, pkg) => {
+    if (err) return cb(err)
+    debug(`Inferring target Electron version from ${packageName} in ${src}`)
+    opts.electronVersion = pkg.version
+    return cb(null)
+  })
+}
+
 module.exports = {
   archs: archs,
   platforms: platforms,
@@ -234,6 +271,63 @@ module.exports = {
 
   generateFinalBasename: generateFinalBasename,
   generateFinalPath: generateFinalPath,
+
+  getMetadataFromPackageJSON: function getMetadataFromPackageJSON (opts, dir, cb) {
+    var props = []
+    if (!opts.name) props.push(['productName', 'name'])
+    if (!opts.appVersion) props.push('version')
+    if (!opts.electronVersion) {
+      props.push([
+        'dependencies.electron',
+        'devDependencies.electron',
+        'dependencies.electron-prebuilt',
+        'devDependencies.electron-prebuilt'
+      ])
+    }
+
+    // Name and version provided, no need to infer
+    if (props.length === 0) return cb(null)
+
+    // Search package.json files to infer name and version from
+    getPackageInfo(props, dir, (err, result) => {
+      if (err && err.missingProps) {
+        let missingProps = err.missingProps.map(prop => {
+          return Array.isArray(prop) ? prop[0] : prop
+        })
+
+        if (isMissingRequiredProperty(missingProps)) {
+          let messages = missingProps.map(errorMessageForProperty)
+
+          debug(err.message)
+          err.message = messages.join('\n') + '\n'
+          return cb(err)
+        } else {
+          // Missing props not required, can continue w/ partial result
+          result = err.result
+        }
+      } else if (err) {
+        return cb(err)
+      }
+
+      if (result.values.productName) {
+        debug(`Inferring application name from ${result.source.productName.prop} in ${result.source.productName.src}`)
+        opts.name = result.values.productName
+      }
+
+      if (result.values.version) {
+        debug(`Inferring appVersion from version in ${result.source.version.src}`)
+        opts.appVersion = result.values.version
+      }
+
+      if (result.values['dependencies.electron']) {
+        let prop = result.source['dependencies.electron'].prop.split('.')[1]
+        let src = result.source['dependencies.electron'].src
+        return getVersion(opts, prop, src, cb)
+      } else {
+        return cb(null)
+      }
+    })
+  },
 
   info: info,
 

--- a/common.js
+++ b/common.js
@@ -5,12 +5,10 @@ const child = require('child_process')
 const debug = require('debug')('electron-packager')
 const download = require('electron-download')
 const fs = require('fs-extra')
-const getPackageInfo = require('get-package-info')
 const ignore = require('./ignore')
 const minimist = require('minimist')
 const os = require('os')
 const path = require('path')
-const resolve = require('resolve')
 const sanitize = require('sanitize-filename')
 const semver = require('semver')
 const series = require('run-series')
@@ -155,45 +153,6 @@ function createDownloadOpts (opts, platform, arch) {
   return downloadOpts
 }
 
-function isMissingRequiredProperty (props) {
-  var requiredProps = props.filter(
-    (prop) => prop === 'productName' || prop === 'dependencies.electron'
-  )
-  return requiredProps.length !== 0
-}
-
-function errorMessageForProperty (prop) {
-  let hash, propDescription
-  switch (prop) {
-    case 'productName':
-      hash = 'name'
-      propDescription = 'application name'
-      break
-    case 'dependencies.electron':
-      hash = 'version'
-      propDescription = 'Electron version'
-      break
-    default:
-      hash = ''
-      propDescription = '[Unknown Property]'
-  }
-
-  return `Unable to determine ${propDescription}. Please specify an ${propDescription}\n\n` +
-    'For more information, please see\n' +
-    `https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#${hash}\n`
-}
-
-function getVersion (opts, packageName, src, cb) {
-  resolve(packageName, {
-    basedir: path.dirname(src)
-  }, (err, res, pkg) => {
-    if (err) return cb(err)
-    debug(`Inferring target Electron version from ${packageName} in ${src}`)
-    opts.electronVersion = pkg.version
-    return cb(null)
-  })
-}
-
 module.exports = {
   archs: archs,
   platforms: platforms,
@@ -275,63 +234,6 @@ module.exports = {
 
   generateFinalBasename: generateFinalBasename,
   generateFinalPath: generateFinalPath,
-
-  getMetadataFromPackageJSON: function getMetadataFromPackageJSON (opts, dir, cb) {
-    let props = []
-    if (!opts.name) props.push(['productName', 'name'])
-    if (!opts.appVersion) props.push('version')
-    if (!opts.electronVersion) {
-      props.push([
-        'dependencies.electron',
-        'devDependencies.electron',
-        'dependencies.electron-prebuilt',
-        'devDependencies.electron-prebuilt'
-      ])
-    }
-
-    // Name and version provided, no need to infer
-    if (props.length === 0) return cb(null)
-
-    // Search package.json files to infer name and version from
-    getPackageInfo(props, dir, (err, result) => {
-      if (err && err.missingProps) {
-        let missingProps = err.missingProps.map(prop => {
-          return Array.isArray(prop) ? prop[0] : prop
-        })
-
-        if (isMissingRequiredProperty(missingProps)) {
-          let messages = missingProps.map(errorMessageForProperty)
-
-          debug(err.message)
-          err.message = messages.join('\n') + '\n'
-          return cb(err)
-        } else {
-          // Missing props not required, can continue w/ partial result
-          result = err.result
-        }
-      } else if (err) {
-        return cb(err)
-      }
-
-      if (result.values.productName) {
-        debug(`Inferring application name from ${result.source.productName.prop} in ${result.source.productName.src}`)
-        opts.name = result.values.productName
-      }
-
-      if (result.values.version) {
-        debug(`Inferring appVersion from version in ${result.source.version.src}`)
-        opts.appVersion = result.values.version
-      }
-
-      if (result.values['dependencies.electron']) {
-        let prop = result.source['dependencies.electron'].prop.split('.')[1]
-        let src = result.source['dependencies.electron'].src
-        return getVersion(opts, prop, src, cb)
-      } else {
-        return cb(null)
-      }
-    })
-  },
 
   info: info,
 

--- a/common.js
+++ b/common.js
@@ -163,18 +163,22 @@ function isMissingRequiredProperty (props) {
 }
 
 function errorMessageForProperty (prop) {
-  let hash, propName
-  if (prop === 'productName') {
-    hash = 'name'
-    propName = 'application name'
+  let hash, propDescription
+  switch (prop) {
+    case 'productName':
+      hash = 'name'
+      propDescription = 'application name'
+      break
+    case 'dependencies.electron':
+      hash = 'version'
+      propDescription = 'Electron version'
+      break
+    default:
+      hash = ''
+      propDescription = '[Unknown Property]'
   }
 
-  if (prop === 'dependencies.electron') {
-    hash = 'version'
-    propName = 'Electron version'
-  }
-
-  return `Unable to determine ${propName}. Please specify an ${propName}\n\n` +
+  return `Unable to determine ${propDescription}. Please specify an ${propDescription}\n\n` +
     'For more information, please see\n' +
     `https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#${hash}\n`
 }
@@ -273,7 +277,7 @@ module.exports = {
   generateFinalPath: generateFinalPath,
 
   getMetadataFromPackageJSON: function getMetadataFromPackageJSON (opts, dir, cb) {
-    var props = []
+    let props = []
     if (!opts.name) props.push(['productName', 'name'])
     if (!opts.appVersion) props.push('version')
     if (!opts.electronVersion) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -140,7 +140,8 @@ but are not limited to:
 The Electron version with which the app is built (without the leading 'v') - for example,
 [`1.4.13`](https://github.com/electron/electron/releases/tag/v1.4.13). See [Electron releases] for
 valid versions. If omitted, it will use the version of the nearest local installation of
-`electron` or `electron-prebuilt`, defined in `package.json` in either `dependencies` or `devDependencies`.
+`electron`, `electron-prebuilt-compile`, or `electron-prebuilt`, defined in `package.json` in either
+`dependencies` or `devDependencies`.
 
 ##### `icon`
 
@@ -284,7 +285,7 @@ Valid values are listed in [Apple's documentation](https://developer.apple.com/l
 
 When the value is a `String`, the filename of a plist file. Its contents are added to the app's plist. When the value is an `Object`, an already-parsed plist data structure that is merged into the app's plist.
 
-Entries from `extend-info` override entries in the base plist file supplied by `electron` or `electron-prebuilt`, but are overridden by other explicit arguments such as [`app-version`](#app-version) or [`app-bundle-id`](#app-bundle-id).
+Entries from `extend-info` override entries in the base plist file supplied by `electron`, `electron-prebuilt-compile`, or `electron-prebuilt`, but are overridden by other explicit arguments such as [`app-version`](#app-version) or [`app-bundle-id`](#app-bundle-id).
 
 ##### `extra-resource`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -176,6 +176,7 @@ described after the list*):
 * `node_modules/.bin`
 * `node_modules/electron`
 * `node_modules/electron-prebuilt`
+* `node_modules/electron-prebuilt-compile`
 * `node_modules/electron-packager`
 * `.git`
 * files and folders ending in `.o` and `.obj`

--- a/ignore.js
+++ b/ignore.js
@@ -5,7 +5,7 @@ const path = require('path')
 
 const DEFAULT_IGNORES = [
   '/node_modules/electron($|/)',
-  '/node_modules/electron-prebuilt($|/)',
+  '/node_modules/electron-prebuilt(-compile)?($|/)',
   '/node_modules/electron-packager($|/)',
   '/\\.git($|/)',
   '/node_modules/\\.bin($|/)',

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const common = require('./common')
 const debug = require('debug')('electron-packager')
 const extract = require('extract-zip')
 const fs = require('fs-extra')
+const getMetadataFromPackageJSON = require('./infer')
 const ignore = require('./ignore')
 const metadata = require('./package.json')
 const path = require('path')
@@ -148,7 +149,7 @@ module.exports = function packager (opts, cb) {
 
   common.camelCase(opts, true)
 
-  common.getMetadataFromPackageJSON(opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {
+  getMetadataFromPackageJSON(opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {
     if (err) return cb(err)
 
     if (/ Helper$/.test(opts.name)) {

--- a/infer.js
+++ b/infer.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const debug = require('debug')('electron-packager')
+const getPackageInfo = require('get-package-info')
+const path = require('path')
+const resolve = require('resolve')
+
+function isMissingRequiredProperty (props) {
+  var requiredProps = props.filter(
+    (prop) => prop === 'productName' || prop === 'dependencies.electron'
+  )
+  return requiredProps.length !== 0
+}
+
+function errorMessageForProperty (prop) {
+  let hash, propDescription
+  switch (prop) {
+    case 'productName':
+      hash = 'name'
+      propDescription = 'application name'
+      break
+    case 'dependencies.electron':
+      hash = 'version'
+      propDescription = 'Electron version'
+      break
+    default:
+      hash = ''
+      propDescription = '[Unknown Property]'
+  }
+
+  return `Unable to determine ${propDescription}. Please specify an ${propDescription}\n\n` +
+    'For more information, please see\n' +
+    `https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#${hash}\n`
+}
+
+function getVersion (opts, packageName, src, cb) {
+  resolve(packageName, {
+    basedir: path.dirname(src)
+  }, (err, res, pkg) => {
+    if (err) return cb(err)
+    debug(`Inferring target Electron version from ${packageName} in ${src}`)
+    opts.electronVersion = pkg.version
+    return cb(null)
+  })
+}
+
+module.exports = function getMetadataFromPackageJSON (opts, dir, cb) {
+  let props = []
+  if (!opts.name) props.push(['productName', 'name'])
+  if (!opts.appVersion) props.push('version')
+  if (!opts.electronVersion) {
+    props.push([
+      'dependencies.electron',
+      'devDependencies.electron',
+      'dependencies.electron-prebuilt',
+      'devDependencies.electron-prebuilt'
+    ])
+  }
+
+  // Name and version provided, no need to infer
+  if (props.length === 0) return cb(null)
+
+  // Search package.json files to infer name and version from
+  getPackageInfo(props, dir, (err, result) => {
+    if (err && err.missingProps) {
+      let missingProps = err.missingProps.map(prop => {
+        return Array.isArray(prop) ? prop[0] : prop
+      })
+
+      if (isMissingRequiredProperty(missingProps)) {
+        let messages = missingProps.map(errorMessageForProperty)
+
+        debug(err.message)
+        err.message = messages.join('\n') + '\n'
+        return cb(err)
+      } else {
+        // Missing props not required, can continue w/ partial result
+        result = err.result
+      }
+    } else if (err) {
+      return cb(err)
+    }
+
+    if (result.values.productName) {
+      debug(`Inferring application name from ${result.source.productName.prop} in ${result.source.productName.src}`)
+      opts.name = result.values.productName
+    }
+
+    if (result.values.version) {
+      debug(`Inferring appVersion from version in ${result.source.version.src}`)
+      opts.appVersion = result.values.version
+    }
+
+    if (result.values['dependencies.electron']) {
+      let prop = result.source['dependencies.electron'].prop.split('.')[1]
+      let src = result.source['dependencies.electron'].src
+      return getVersion(opts, prop, src, cb)
+    } else {
+      return cb(null)
+    }
+  })
+}

--- a/test/fixtures/infer-electron-prebuilt-compile/package.json
+++ b/test/fixtures/infer-electron-prebuilt-compile/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "main.js",
+  "productName": "MainJS",
+  "devDependencies": {
+    "electron-prebuilt-compile": "1.4.15"
+  }
+}

--- a/test/fixtures/infer-non-specific-electron-prebuilt-compile/package.json
+++ b/test/fixtures/infer-non-specific-electron-prebuilt-compile/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "main.js",
+  "productName": "MainJS",
+  "devDependencies": {
+    "electron-prebuilt-compile": "^1.4.15"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -50,6 +50,7 @@ series(setupFuncs, (error) => {
   require('./asar')
   require('./cli')
   require('./ignore')
+  require('./infer')
   require('./hooks')
   require('./multitarget')
   require('./win32')

--- a/test/infer.js
+++ b/test/infer.js
@@ -1,0 +1,113 @@
+'use strict'
+
+const config = require('./config.json')
+const fs = require('fs-extra')
+const getMetadataFromPackageJSON = require('../infer')
+const os = require('os')
+const packager = require('..')
+const path = require('path')
+const pkgUp = require('pkg-up')
+const util = require('./util')
+const waterfall = require('run-waterfall')
+
+function createInferElectronVersionTest (fixture, packageName) {
+  return (opts) => {
+    return (t) => {
+      t.timeoutAfter(config.timeout)
+
+      // Don't specify name or version
+      delete opts.electronVersion
+      opts.dir = path.join(__dirname, 'fixtures', fixture)
+
+      waterfall([
+        (cb) => {
+          getMetadataFromPackageJSON(opts, opts.dir, cb)
+        }, (cb) => {
+          fs.readFile(path.join(opts.dir, 'package.json'), cb)
+        }, (pkg, cb) => {
+          const packageJSON = JSON.parse(pkg)
+          t.equal(opts.electronVersion, packageJSON.devDependencies[packageName], `The version should be inferred from installed ${packageName} version`)
+          cb()
+        }
+      ], (err) => {
+        t.end(err)
+      })
+    }
+  }
+}
+
+function copyFixtureToTempDir (fixtureSubdir, cb) {
+  let tmpdir = path.join(os.tmpdir(), fixtureSubdir)
+  let fixtureDir = path.join(__dirname, 'fixtures', fixtureSubdir)
+  waterfall([
+    cb => {
+      let tmpdirPkg = pkgUp.sync(path.join(tmpdir, '..'))
+      if (tmpdirPkg) return cb(new Error(`Found package.json in parent of temp directory, which will interfere with test results. Please remove package.json at ${tmpdirPkg}`))
+      cb()
+    },
+    cb => fs.emptyDir(tmpdir, cb),
+    (cb1, cb2) => fs.copy(fixtureDir, tmpdir, cb2 || cb1), // inconsistent cb arguments from fs.emptyDir
+    cb => cb(null, tmpdir)
+  ], cb)
+}
+
+function createInferFailureTest (opts, fixtureSubdir) {
+  return function (t) {
+    t.timeoutAfter(config.timeout)
+
+    copyFixtureToTempDir(fixtureSubdir, (err, dir) => {
+      if (err) return t.end(err)
+
+      delete opts.electronVersion
+      opts.dir = dir
+
+      packager(opts, function (err, paths) {
+        t.ok(err, 'error thrown')
+        t.end()
+      })
+    })
+  }
+}
+
+function createInferMissingVersionTest (opts) {
+  return (t) => {
+    t.timeoutAfter(config.timeout)
+    waterfall([
+      (cb) => {
+        copyFixtureToTempDir('infer-missing-version-only', cb)
+      }, (dir, cb) => {
+        delete opts.electronVersion
+        opts.dir = dir
+
+        getMetadataFromPackageJSON(opts, dir, cb)
+      }, (cb) => {
+        fs.readFile(path.join(opts.dir, 'package.json'), cb)
+      }, (pkg, cb) => {
+        const packageJSON = JSON.parse(pkg)
+        t.equal(opts.electronVersion, packageJSON.devDependencies['electron'], 'The version should be inferred from installed electron module version')
+        cb()
+      }
+    ], (err) => {
+      t.end(err)
+    })
+  }
+}
+
+function createInferMissingFieldsTest (opts) {
+  return createInferFailureTest(opts, 'infer-missing-fields')
+}
+
+function createInferWithBadFieldsTest (opts) {
+  return createInferFailureTest(opts, 'infer-bad-fields')
+}
+
+function createInferWithMalformedJSONTest (opts) {
+  return createInferFailureTest(opts, 'infer-malformed-json')
+}
+
+util.testSinglePlatform('infer using `electron-prebuilt` package', createInferElectronVersionTest('basic', 'electron-prebuilt'))
+util.testSinglePlatform('infer using `electron` package only', createInferMissingVersionTest)
+util.testSinglePlatform('infer where `electron` version is preferred over `electron-prebuilt`', createInferElectronVersionTest('basic-renamed-to-electron', 'electron'))
+util.testSinglePlatform('infer missing fields test', createInferMissingFieldsTest)
+util.testSinglePlatform('infer with bad fields test', createInferWithBadFieldsTest)
+util.testSinglePlatform('infer with malformed JSON test', createInferWithMalformedJSONTest)

--- a/test/infer.js
+++ b/test/infer.js
@@ -105,9 +105,15 @@ function createInferWithMalformedJSONTest (opts) {
   return createInferFailureTest(opts, 'infer-malformed-json')
 }
 
+function createInferNonSpecificElectronPrebuiltCompileFailureTest (opts) {
+  return createInferFailureTest(opts, 'infer-non-specific-electron-prebuilt-compile')
+}
+
 util.testSinglePlatform('infer using `electron-prebuilt` package', createInferElectronVersionTest('basic', 'electron-prebuilt'))
+util.testSinglePlatform('infer using `electron-prebuilt-compile` package', createInferElectronVersionTest('infer-electron-prebuilt-compile', 'electron-prebuilt-compile'))
 util.testSinglePlatform('infer using `electron` package only', createInferMissingVersionTest)
 util.testSinglePlatform('infer where `electron` version is preferred over `electron-prebuilt`', createInferElectronVersionTest('basic-renamed-to-electron', 'electron'))
 util.testSinglePlatform('infer missing fields test', createInferMissingFieldsTest)
 util.testSinglePlatform('infer with bad fields test', createInferWithBadFieldsTest)
 util.testSinglePlatform('infer with malformed JSON test', createInferWithMalformedJSONTest)
+util.testSinglePlatform('infer using a non-specific `electron-prebuilt-compile` package version', createInferNonSpecificElectronPrebuiltCompileFailureTest)


### PR DESCRIPTION
* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* [X] The changes have sufficient test coverage (if applicable).
* [X] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Refactored the code so that all of the option inferring from `package.json` is in its own file (same with its tests). Adds limited support for inferring the Electron version of projects using `electron-prebuilt-compile`.

Of interest to @paulcbetts: I found out that the `main` key in `electron-prebuilt-compile` isn't pointing to a real file, so I can't do `resolve('electron-prebuilt-compile')` like I can with the others. I wonder if it's worth having `resolve` parity with the canonical `electron` module moving forward?

Of interest to @MarshallOfSound: This could get rid of the "Forge needs to explicitly specify the Electron version" code in the package stage.