### PR TITLE
Add support for updating the application manifest and requested execution level for Windows targets

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -375,6 +375,10 @@ Object (also known as a "hash") of application metadata to embed into the execut
 - `OriginalFilename`
 - `ProductName`
 - `InternalName`
+- `requested-execution-level`
+- `application-manifest`
+
+For more information, see the [node-rcedit module](https://github.com/electron/node-rcedit).
 
 ## callback
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "get-package-info": "^1.0.0",
     "minimist": "^1.1.1",
     "plist": "^2.0.0",
-    "rcedit": "^0.8.0",
+    "rcedit": "^0.9.0",
     "resolve": "^1.1.6",
     "run-series": "^1.1.1",
     "sanitize-filename": "^1.6.0",

--- a/test/win32.js
+++ b/test/win32.js
@@ -93,15 +93,30 @@ function setCopyrightAndCompanyNameTest (appCopyright, companyName) {
 function setRequestedExecutionLevelTest (requestedExecutionLevel) {
   var opts = {
     win32metadata: {
-      requestedExecutionLevel: 'asInvoker'
+      'requested-execution-level': requestedExecutionLevel
     }
   }
 
   return generateVersionStringTest(
-    'win32metadata',
+    'requested-execution-level',
     opts,
-    {requestedExecutionLevel: requestedExecutionLevel},
-    'requestedExecutionLevel in win32metadata should match win32metadata value '
+    requestedExecutionLevel,
+    'requested-execution-level in win32metadata should match rcOpts value'
+  )
+}
+
+function setApplicationManifestTest (applicationManifest) {
+  var opts = {
+    win32metadata: {
+      'application-manifest': applicationManifest
+    }
+  }
+
+  return generateVersionStringTest(
+    'application-manifest',
+    opts,
+    applicationManifest,
+    'application-manifest in win32metadata should match rcOpts value'
   )
 }
 
@@ -174,4 +189,5 @@ util.packagerTest('win32 app copyright sets LegalCopyright test', setCopyrightTe
 util.packagerTest('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
 util.packagerTest('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))
 util.packagerTest('win32 set CompanyName test (version-string)', setCompanyNameTest('MyCompany LLC', 'version-string'))
-util.packagerTest('win32 set requestedExecutionLevel test (win32metadata)', setRequestedExecutionLevelTest('asInvoker'))
+util.packagerTest('win32 set requested-execution-level test (win32metadata)', setRequestedExecutionLevelTest('asInvoker'))
+util.packagerTest('win32 set application-manifest test (win32metadata)', setApplicationManifestTest('/path/to/manifest.xml'))

--- a/test/win32.js
+++ b/test/win32.js
@@ -90,6 +90,21 @@ function setCopyrightAndCompanyNameTest (appCopyright, companyName) {
   )
 }
 
+function setRequestedExecutionLevelTest (requestedExecutionLevel) {
+  var opts = {
+    win32metadata: {
+      requestedExecutionLevel: 'asInvoker'
+    }
+  }
+
+  return generateVersionStringTest(
+    'win32metadata',
+    opts,
+    {requestedExecutionLevel: requestedExecutionLevel},
+    'requestedExecutionLevel in win32metadata should match win32metadata value '
+  )
+}
+
 function setCompanyNameTest (companyName, optName) {
   let opts = {}
   opts[optName] = {
@@ -159,3 +174,4 @@ util.packagerTest('win32 app copyright sets LegalCopyright test', setCopyrightTe
 util.packagerTest('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
 util.packagerTest('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))
 util.packagerTest('win32 set CompanyName test (version-string)', setCompanyNameTest('MyCompany LLC', 'version-string'))
+util.packagerTest('win32 set requestedExecutionLevel test (win32metadata)', setRequestedExecutionLevelTest('asInvoker'))

--- a/usage.txt
+++ b/usage.txt
@@ -94,3 +94,4 @@ win32metadata      a list of sub-properties used to set the application metadata
                    - OriginalFilename
                    - ProductName
                    - InternalName
+                   - requestedExecutionLevel (user, asInvoker or requireAdministrator)

--- a/win32.js
+++ b/win32.js
@@ -22,6 +22,13 @@ function generateRceditOptionsSansIcon (opts) {
     rcOpts['version-string'].LegalCopyright = opts.appCopyright
   }
 
+  const manifestProperties = ['application-manifest', 'requested-execution-level']
+  for (const manifestProperty of manifestProperties) {
+    if (win32metadata[manifestProperty]) {
+      rcOpts[manifestProperty] = win32metadata[manifestProperty]
+    }
+  }
+
   return rcOpts
 }
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

As per http://layer0.authentise.com/electron-and-uac-on-windows.html, have added the ability for rcedit.exe to modify the requested execution level, so that the Electron app can have administrator privileges.  https://github.com/dmascord/rcedit and https://github.com/dmascord/node-rcedit have been updated appropriately, and a pull request has been issued for them too.

Fixes #197.