### PR TITLE
Add max-buffer-size option for the parameter for pruning child process

### DIFF
--- a/common.js
+++ b/common.js
@@ -33,6 +33,7 @@ function parseCLIArgs (argv) {
     },
     string: [
       'electron-version',
+      'max-buffer-size',
       'out'
     ]
   })
@@ -294,7 +295,13 @@ module.exports = {
     if (opts.prune || opts.prune === undefined) {
       operations.push(function (cb) {
         debug('Running npm prune --production')
-        child.exec('npm prune --production', {cwd: appPath}, cb)
+        var bufferSize = 200; // default value in child.exec
+        var bs = opts['max-buffer-size']
+        if(Number(bs) > 0) {
+          bufferSize = bs;
+          debug('now buffer size is ' + bufferSize + 'MB')
+        }
+        child.exec('npm prune --production', {cwd: appPath, maxBuffer: bufferSize * 1024}, cb)
       })
     }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Hi.

I think it might be better if this command has "max-buffer-size" cli option (optional).

This patch enables users to avoid "stdout maxBuffer exceeded" error when
the size of pruning targets is larger than 200MB (default for child.exec).

In my case, the existence of many dependencies in package.json causes  "stdout maxBuffer exceeded" without "--no-prune" option.
