### PR TITLE
Travis: Re-enable Node 5/OSX, Downgrade to npm@4 for Node 8/OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ branches:
   only:
   - master
   - /^v\d+\.\d+\.\d+/
-matrix:
-  allow_failures:
-  - node_js: '5'
-    os: osx
 env:
   global:
     # coveralls token

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -13,6 +13,10 @@ case "$TRAVIS_OS_NAME" in
     sudo apt-get install -y wine1.6 yarn
     ;;
   "osx")
+    # Force NPM 4.x if Node 8
+    if test "$TRAVIS_NODE_VERSION" = "8"; then
+      npm install -g npm@4
+    fi
     # Create CA
     openssl req -newkey rsa:4096 -days 1 -x509 -nodes -subj \
       "/C=CI/ST=Travis/L=Developer/O=Developer/CN=Developer CA" \


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* ~~The changes have sufficient test coverage~~ (not applicable).
* ~~The testsuite passes successfully on my local machine~~ (not applicable).

**Summarize your changes:**

`npm@5` (strangely, just on OSX) doesn't install modules correctly for some reason. Example:
https://travis-ci.org/electron-userland/electron-packager/jobs/239192709

Closes #598.