### PR TITLE
Remove deprecated version option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
 * Promise support for `packager` - function returns a Promise instead of the return value of the
   callback (#658)
 
+### Removed
+
+* `version` is removed in favor of `electronVersion` (CLI: `--electron-version`) (#665)
+
 ## [8.7.0] - 2017-05-01
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -263,11 +263,6 @@ application. This does *not* disable errors.
 
 The base directory to use as a temp directory. Set to `false` to disable use of a temporary directory.
 
-##### `version`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-[`electronVersion`](#electronversion) parameter instead)
-
 #### OS X/Mac App Store targets only
 
 ##### `app-bundle-id`

--- a/index.js
+++ b/index.js
@@ -148,8 +148,6 @@ module.exports = pify(function packager (opts, cb) {
   debug(`Target Platforms: ${platforms.join(', ')}`)
   debug(`Target Architectures: ${archs.join(', ')}`)
 
-  common.deprecatedParameter(opts, 'version', 'electronVersion', 'electron-version')
-
   common.camelCase(opts, true)
 
   getMetadataFromPackageJSON(opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -299,6 +299,24 @@ test('cannot build apps where the name ends in " Helper"', (t) => {
     )
 })
 
+test('deprecatedParameter moves value in deprecated param to new param if new param is not set', (t) => {
+  let opts = {
+    old: 'value'
+  }
+  common.deprecatedParameter(opts, 'old', 'new', 'new-value')
+
+  t.false(opts.hasOwnProperty('old'), 'old property is not set')
+  t.true(opts.hasOwnProperty('new'), 'new property is set')
+
+  opts.not_overwritten_old = 'another'
+  common.deprecatedParameter(opts, 'not_overwritten_old', 'new', 'new-value')
+
+  t.false(opts.hasOwnProperty('not_overwritten_old'), 'not_overwritten_old property is not set')
+  t.true(opts.hasOwnProperty('new'), 'new property is set')
+  t.equal('value', opts.new, 'new property is not overwritten')
+  t.end()
+})
+
 util.testSinglePlatform('defaults test', createDefaultsTest)
 util.testSinglePlatform('out test', createOutTest)
 util.testSinglePlatform('overwrite test', createOverwriteTest)

--- a/test/basic.js
+++ b/test/basic.js
@@ -344,31 +344,6 @@ util.packagerTest('fails with invalid version', invalidOptionTest({
   }
 }))
 
-util.packagerTest('electronVersion overrides deprecated version', (t) => {
-  const opts = {
-    electronVersion: '0.1.2',
-    version: '1.2.3'
-  }
-
-  common.deprecatedParameter(opts, 'version', 'electronVersion')
-
-  t.equal(opts.electronVersion, '0.1.2', 'electronVersion should not change')
-  t.equal(opts.version, undefined, 'version should be deleted')
-  t.end()
-})
-
-util.packagerTest('version used if electronVersion not set', (t) => {
-  const opts = {
-    version: '1.2.3'
-  }
-
-  common.deprecatedParameter(opts, 'version', 'electronVersion')
-
-  t.equal(opts.electronVersion, '1.2.3', 'electronVersion have version value')
-  t.equal(opts.version, undefined, 'version should be deleted')
-  t.end()
-})
-
 util.packagerTest('dir argument test: should work with relative path', (t) => {
   const opts = {
     name: 'ElectronTest',

--- a/usage.txt
+++ b/usage.txt
@@ -57,7 +57,6 @@ platform           all, or one or more of: darwin, linux, mas, win32 (comma-deli
 quiet              Do not print informational or warning messages
 tmpdir             temp directory. Defaults to system temp directory, use --tmpdir=false to disable
                    use of a temporary directory.
-version            an alias for electron-version (deprecated)
 
 * darwin/mas target platforms only *
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Drop `version` since `electronVersion` support has been out for a while. Will probably add `--version` back (that works like a normal `--version` param) in version 10.

Fixes #154.