### PR TITLE
Remove deprecated version-string option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 ### Removed
 
 * `version` is removed in favor of `electronVersion` (CLI: `--electron-version`) (#665)
+* `version-string` is removed in favor of `win32metadata`
 
 ## [8.7.0] - 2017-05-01
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -363,11 +363,6 @@ option. Maps to the `CFBundleURLName` metadata property.
 
 #### Windows targets only
 
-##### `version-string`
-
-*Object* (**deprecated** and will be removed in a future major version, please use the
-[`win32metadata`](#win32metadata) parameter instead)
-
 ##### `win32metadata`
 
 *Object*

--- a/test/win32.js
+++ b/test/win32.js
@@ -125,16 +125,17 @@ function setApplicationManifestTest (applicationManifest) {
   )
 }
 
-function setCompanyNameTest (companyName, optName) {
-  let opts = {}
-  opts[optName] = {
-    CompanyName: companyName
+function setCompanyNameTest (companyName) {
+  const opts = {
+    win32metadata: {
+      CompanyName: companyName
+    }
   }
 
   return generateVersionStringTest('version-string',
                                    opts,
                                    {CompanyName: companyName},
-                                   `Company name should match ${optName} value`)
+                                   `Company name should match win32metadata value`)
 }
 
 test('better error message when wine is not found', (t) => {
@@ -200,7 +201,6 @@ util.packagerTest('win32 build version sets FileVersion test', setFileVersionTes
 util.packagerTest('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
 util.packagerTest('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
 util.packagerTest('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
-util.packagerTest('win32 set CompanyName test (win32metadata)', setCompanyNameTest('MyCompany LLC', 'win32metadata'))
-util.packagerTest('win32 set CompanyName test (version-string)', setCompanyNameTest('MyCompany LLC', 'version-string'))
-util.packagerTest('win32 set requested-execution-level test (win32metadata)', setRequestedExecutionLevelTest('asInvoker'))
-util.packagerTest('win32 set application-manifest test (win32metadata)', setApplicationManifestTest('/path/to/manifest.xml'))
+util.packagerTest('win32 set CompanyName test', setCompanyNameTest('MyCompany LLC'))
+util.packagerTest('win32 set requested-execution-level test', setRequestedExecutionLevelTest('asInvoker'))
+util.packagerTest('win32 set application-manifest test', setApplicationManifestTest('/path/to/manifest.xml'))

--- a/usage.txt
+++ b/usage.txt
@@ -82,7 +82,6 @@ protocol-name      Descriptive name of URL protocol scheme specified via `--prot
 
 * win32 target platform only *
 
-version-string     an alias for win32metadata (deprecated)
 win32metadata      a list of sub-properties used to set the application metadata embedded into
                    the executable. They are specified via dot notation,
                    e.g. --win32metadata.CompanyName="Company Inc."

--- a/win32.js
+++ b/win32.js
@@ -11,7 +11,7 @@ function generateRceditOptionsSansIcon (opts, newExeName) {
     InternalName: opts.name,
     OriginalFilename: newExeName,
     ProductName: opts.name
-  }, opts['version-string'], opts.win32metadata)
+  }, opts.win32metadata)
 
   let rcOpts = {'version-string': win32metadata}
 
@@ -63,7 +63,7 @@ module.exports = {
 
       const rcOpts = generateRceditOptionsSansIcon(opts, newExeName)
 
-      if (opts.icon || opts.win32metadata || opts['version-string'] || opts.appCopyright || opts.appVersion || opts.buildVersion) {
+      if (opts.icon || opts.win32metadata || opts.appCopyright || opts.appVersion || opts.buildVersion) {
         operations.push(function (cb) {
           common.normalizeExt(opts.icon, '.ico', function (err, icon) {
             // Icon might be omitted or only exist in one OS's format, so skip it if normalizeExt reports an error


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Pretty self-explanatory. Please use `win32metadata` instead (which was added in version 8.0.0, in September 2016).