### PR TITLE
Remove support for hyphenated option names via JS API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * `version` is removed in favor of `electronVersion` (CLI: `--electron-version`) (#665)
 * `version-string` is removed in favor of `win32metadata`
+* Options set via the JavaScript API formatted in kebab-case (i.e., with hyphens) are removed in
+  favor of their camelCase variants, per JavaScript naming standards
 
 ## [8.7.0] - 2017-05-01
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,21 +59,11 @@ An array of functions to be called after Electron has been extracted to a tempor
 
 When `true`, sets both [`arch`](#arch) and [`platform`](#platform) to `all`.
 
-##### `app-copyright`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-[`appCopyright`](#appcopyright) parameter instead)
-
 ##### `appCopyright`
 
 *String*
 
 The human-readable copyright line for the app. Maps to the `LegalCopyright` metadata property on Windows, and `NSHumanReadableCopyright` on OS X.
-
-##### `app-version`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-[`appVersion`](#appversion) parameter instead)
 
 ##### `appVersion`
 
@@ -108,12 +98,6 @@ Whether to package the application's source code into an archive, using [Electro
   - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/*'` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`, but it will not include their subdirectories.
   - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/**'` will unpack the subdirectories of the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2`.
   - `asar.unpackDir = '**/{sub_dir1/sub_sub_dir,sub_dir2}/**/*'` will unpack the directories `/<dir>/sub_dir1/sub_sub_dir` and `/<dir>/sub_dir2` and their subdirectories.
-
-##### `build-version`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-[`buildVersion`](#buildversion) parameter instead)
-
 
 ##### `buildVersion`
 
@@ -265,21 +249,11 @@ The base directory to use as a temp directory. Set to `false` to disable use of 
 
 #### OS X/Mac App Store targets only
 
-##### `app-bundle-id`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-[`appBundleId`](#appbundleid) parameter instead)
-
 ##### `appBundleId`
 
 *String*
 
 The bundle identifier to use in the application's plist.
-
-##### `app-category-type`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-  [`appCategoryType`](#appcategorytype) parameter instead)
 
 ##### `appCategoryType`
 
@@ -291,11 +265,6 @@ For example, `app-category-type=public.app-category.developer-tools` will set th
 
 Valid values are listed in [Apple's documentation](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW8).
 
-##### `extend-info`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-  [`extendInfo`](#extendinfo) parameter instead)
-
 ##### `extendInfo`
 
 *String* or *Object*
@@ -304,32 +273,17 @@ When the value is a `String`, the filename of a plist file. Its contents are add
 
 Entries from `extend-info` override entries in the base plist file supplied by `electron`, `electron-prebuilt-compile`, or `electron-prebuilt`, but are overridden by other explicit arguments such as [`appVersion`](#appversion) or [`appBundleId`](#appbundleid).
 
-##### `extra-resource`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-  [`extraResource`](#extraresource) parameter instead)
-
 ##### `extraResource`
 
 *String* or *Array*
 
 Filename of a file to be copied directly into the app's `Contents/Resources` directory.
 
-##### `helper-bundle-id`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-  [`helperBundleId`](#helperbundleid) parameter instead)
-
 ##### `helperBundleId`
 
 *String*
 
 The bundle identifier to use in the application helper's plist.
-
-##### `osx-sign`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-  [`osxSign`](#osxsign) parameter instead)
 
 ##### `osxSign`
 
@@ -348,11 +302,6 @@ The URL protocol scheme(s) to associate the app with. For example, specifying
 `myapp` would cause URLs such as `myapp://path` to be opened with the app. Maps
 to the `CFBundleURLSchemes` metadata property. This option requires a
 corresponding `protocol-name` option to be specified.
-
-##### `protocol-name`
-
-*String* (**deprecated** and will be removed in a future major version, please use the
-[`protocolName`](#protocolname) parameter instead)
 
 ##### `protocolName`
 

--- a/index.js
+++ b/index.js
@@ -148,8 +148,6 @@ module.exports = pify(function packager (opts, cb) {
   debug(`Target Platforms: ${platforms.join(', ')}`)
   debug(`Target Architectures: ${archs.join(', ')}`)
 
-  common.camelCase(opts, true)
-
   getMetadataFromPackageJSON(platforms, opts, path.resolve(process.cwd(), opts.dir) || process.cwd(), function (err) {
     if (err) return cb(err)
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
     "asar": "^0.13.0",
+    "camelize": "^1.0.0",
     "debug": "^2.2.0",
     "electron-download": "^4.0.0",
     "electron-osx-sign": "^0.4.1",

--- a/test/basic.js
+++ b/test/basic.js
@@ -215,19 +215,6 @@ function invalidOptionTest (opts) {
   }
 }
 
-test('camelCase de-kebab-cases known parameters', (t) => {
-  let opts = {
-    'abc-def': true,
-    'electron-version': '1.6.0'
-  }
-  common.camelCase(opts, false)
-  t.equal('1.6.0', opts.electronVersion, 'camelCased known property exists')
-  t.equal(undefined, opts['electron-version'], 'kebab-cased known property does not exist')
-  t.equal(undefined, opts.abcDef, 'camelCased unknown property does not exist')
-  t.equal(true, opts['abc-def'], 'kebab-cased unknown property exists')
-  t.end()
-})
-
 test('validateListFromOptions does not take non-Array/String values', (t) => {
   t.notOk(targets.validateListFromOptions({digits: 64}, {'64': true, '65': true}, 'digits') instanceof Array,
           'should not be an Array')

--- a/test/cli.js
+++ b/test/cli.js
@@ -45,7 +45,7 @@ test('CLI argument test: --tmpdir=false', function (t) {
 
 test('CLI argument test: --deref-symlinks default', function (t) {
   var args = common.parseCLIArgs([])
-  t.equal(args['deref-symlinks'], true)
+  t.equal(args.derefSymlinks, true)
   t.end()
 })
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

They have been replaced with camelCased names. CLI options remain the same (it uses `camelize` to convert the names).

This is a continuation of #580.