### PR TITLE
Add afterPrune hook

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* API hook for afterPrune (#677)
+
 ### Changed
 
 * Promise support for `packager` - function returns a Promise instead of the return value of the

--- a/common.js
+++ b/common.js
@@ -257,6 +257,14 @@ module.exports = {
       operations.push(function (cb) {
         pruneModules(opts, appPath, cb)
       })
+      operations.push(function (cb) {
+        var afterPruneHooks = (opts.afterPrune || []).map(function (afterPruneFn) {
+          return function (cb) {
+            afterPruneFn(appPath, opts.electronVersion, opts.platform, opts.arch, cb)
+          }
+        })
+        series(afterPruneHooks, cb)
+      })
     }
 
     let asarOptions = createAsarOpts(opts)

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,6 +53,21 @@ An array of functions to be called after Electron has been extracted to a tempor
 - `arch` (*String*): The target architecture you are packaging for
 - `callback` (*Function*): Must be called once you have completed your actions
 
+##### `afterPrune`
+
+*Array of Functions*
+
+An array of functions to be called after the prune command has been run
+in the temporary directory.  Each function is called with five parameters:
+
+- `buildPath` (*String*): The path to the temporary folder where your app has been copied to
+- `electronVersion` (*String*): The version of electron you are packaging for
+- `platform` (*String*): The target platform you are packaging for
+- `arch` (*String*): The target architecture you are packaging for
+- `callback` (*Function*): Must be called once you have completed your actions
+
+**NOTE:** None of these functions will be called if the `prune` option is `false`.
+
 ##### `all`
 
 *Boolean*

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ function createSeries (opts, archs, platforms) {
         comboOpts.platform = platform
         comboOpts.version = version
         comboOpts.afterCopy = opts.afterCopy
+        comboOpts.afterPrune = opts.afterPrune
 
         if (!useTempDir) {
           createApp(comboOpts)

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -37,4 +37,5 @@ function createHookTest (hookName) {
 }
 
 createHookTest('afterCopy')
+createHookTest('afterPrune')
 createHookTest('afterExtract')


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Added an `afterPrune` hook for handling changes that affect ASAR logic in the `prune` step.