### PR TITLE
Do not add .bin folders when pruning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,12 @@
 * Options set via the JavaScript API formatted in kebab-case (i.e., with hyphens) are removed in
   favor of their camelCase variants, per JavaScript naming standards (#669)
 
+## [8.7.2] - 2017-06-25
+
+### Fixed
+
+* Stop yarn creating `.bin` folders when pruning (#678)
+
 ## [8.7.1] - 2017-06-05
 
 ### Fixed
@@ -391,6 +397,8 @@
 
 For versions prior to 5.2.0, please see `git log`.
 
+[8.7.2]: https://github.com/electron-userland/electron-packager/compare/v8.7.1...v8.7.2
+[8.7.1]: https://github.com/electron-userland/electron-packager/compare/v8.7.0...v8.7.1
 [8.7.0]: https://github.com/electron-userland/electron-packager/compare/v8.6.0...v8.7.0
 [8.6.0]: https://github.com/electron-userland/electron-packager/compare/v8.5.2...v8.6.0
 [8.5.2]: https://github.com/electron-userland/electron-packager/compare/v8.5.1...v8.5.2

--- a/prune.js
+++ b/prune.js
@@ -11,7 +11,7 @@ function pruneCommand (packageManager) {
     case 'cnpm':
       return `${packageManager} prune --production`
     case 'yarn':
-      return `${packageManager} install --production`
+      return `${packageManager} install --production --no-bin-links`
   }
 }
 

--- a/test/prune.js
+++ b/test/prune.js
@@ -45,7 +45,7 @@ function createPruneOptionTest (baseOpts, prune, testMessage) {
 test('pruneCommand returns the correct command when passing a known package manager', (t) => {
   t.equal(prune.pruneCommand('npm'), 'npm prune --production', 'passing npm gives the npm prune command')
   t.equal(prune.pruneCommand('cnpm'), 'cnpm prune --production', 'passing cnpm gives the cnpm prune command')
-  t.equal(prune.pruneCommand('yarn'), 'yarn install --production', 'passing yarn gives the yarn "prune command"')
+  t.equal(prune.pruneCommand('yarn'), 'yarn install --production --no-bin-links', 'passing yarn gives the yarn "prune command"')
   t.end()
 })
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`yarn install` by default resurrects the `.bin` folders which breaks ASAR support as they are symlinked files.  This will stop `yarn` creating those folders