### PR TITLE
Stating default Windows generated package size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Electron Packager is a command line tool and Node.js library that bundles Electr
 source code with a renamed Electron executable and supporting files into folders ready for distribution.
 
 Note that packaged Electron applications can be relatively large. A zipped barebones OS X Electron application is around 40MB.
+On Windows 64-bits, default package is 127MB.
 
 ### Electron Packager is an [OPEN Open Source Project](http://openopensource.org/)
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Stating default Windows generated package size on README.md