### PR TITLE
Add option to use custom pruning module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ### Added
 
 * API hook for afterPrune (#677)
+* Package manager-agnostic pruning support (set `packageManager` to `false`) (#690)
 
 ### Changed
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,7 +228,7 @@ Whether to replace an already existing output directory for a given platform (`t
 
 ##### `packageManager`
 
-*String* | *Boolean* (default: `npm`)
+*String* or *Boolean* (default: `npm`)
 
 The package manager used to [prune](#prune) `devDependencies` modules from the outputted Electron
 app. Supported package managers:

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,7 +228,7 @@ Whether to replace an already existing output directory for a given platform (`t
 
 ##### `packageManager`
 
-*String* (default: `npm`)
+*String* | *Boolean* (default: `npm`)
 
 The package manager used to [prune](#prune) `devDependencies` modules from the outputted Electron
 app. Supported package managers:
@@ -237,6 +237,9 @@ app. Supported package managers:
 * [`cnpm`](https://github.com/cnpm/cnpm) (Does not currently work with Windows, see
   [GitHub issue](https://github.com/electron-userland/electron-packager/issues/515#issuecomment-297604044))
 * [`yarn`](https://yarnpkg.com/)
+
+If set to `false` we will use a custom [pruning module](https://www.npmjs.com/package/pruner) to walk your dependency
+tree and prune your dependencies for you.
 
 ##### `platform`
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "parse-author": "^2.0.0",
     "pify": "^3.0.0",
     "plist": "^2.0.0",
-    "pruner": "^0.0.5",
+    "pruner": "^0.0.7",
     "rcedit": "^0.9.0",
     "resolve": "^1.1.6",
     "run-series": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "parse-author": "^2.0.0",
     "pify": "^3.0.0",
     "plist": "^2.0.0",
+    "pruner": "^0.0.5",
     "rcedit": "^0.9.0",
     "resolve": "^1.1.6",
     "run-series": "^1.1.1",

--- a/prune.js
+++ b/prune.js
@@ -2,7 +2,7 @@
 
 const child = require('child_process')
 const debug = require('debug')('electron-packager')
-const { Walker } = require('pruner')
+const Walker = require('pruner').Walker
 
 const knownPackageManagers = ['npm', 'cnpm', 'yarn']
 

--- a/test/prune.js
+++ b/test/prune.js
@@ -75,6 +75,12 @@ util.testSinglePlatform('prune test with npm', (baseOpts) => {
   return createPruneOptionTest(baseOpts, true, 'package.json devDependency should NOT exist under app/node_modules')
 })
 
+// Not in the loop because it doesn't depend on an executable
+util.testSinglePlatform('prune test using pruner module (packageManager=false)', (baseOpts) => {
+  const opts = Object.assign({packageManager: false}, baseOpts)
+  return createPruneOptionTest(opts, true, 'package.json devDependency should NOT exist under app/node_modules')
+})
+
 for (const packageManager of ['cnpm', 'yarn']) {
   which(packageManager, (err, resolvedPath) => {
     if (err) return


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This should help avoid package manager specific pruning issues as we now walk the dependency tree manually.

