### PR TITLE
Add ARM64 support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 * API hook for afterPrune (#677)
 * Package manager-agnostic pruning support (set `packageManager` to `false`) (#690)
+* `linux` platform, `arm64` builds (Electron 1.8.0 and above)
 
 ### Changed
 
@@ -24,6 +25,8 @@
   is specified (#670)
 * Allow spaces when specifying archs/platforms as a string, rather than an array (#487)
 * The `extraResource` option works on all target platforms (#637)
+* `all` or `platform=linux, arch=all` now include `arch=arm64` if the Electron version specified is
+  1.8.0 or above
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * API hook for afterPrune (#677)
 * Package manager-agnostic pruning support (set `packageManager` to `false`) (#690)
-* `linux` platform, `arm64` builds (Electron 1.8.0 and above)
+* `linux` platform, `arm64` builds (Electron 1.8.0 and above) (#711)
 
 ### Changed
 
@@ -26,7 +26,7 @@
 * Allow spaces when specifying archs/platforms as a string, rather than an array (#487)
 * The `extraResource` option works on all target platforms (#637)
 * `all` or `platform=linux, arch=all` now include `arch=arm64` if the Electron version specified is
-  1.8.0 or above
+  1.8.0 or above (#711)
 
 ### Fixed
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,7 +90,7 @@ The release version of the application. By default the `version` property in the
 
 *String* (default: the arch of the host computer running Node)
 
-Allowed values: `ia32`, `x64`, `armv7l`, `all`
+Allowed values: `ia32`, `x64`, `armv7l`, `arm64` _(Electron 1.8.0 and above)_, `all`
 
 The target system architecture(s) to build for.
 Not required if the [`all`](#all) option is set.

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ It generates executables/bundles for the following **target** platforms:
 
 * Windows (also known as `win32`, for both 32/64 bit)
 * OS X (also known as `darwin`) / [Mac App Store](http://electron.atom.io/docs/v0.36.0/tutorial/mac-app-store-submission-guide/) (also known as `mas`)<sup>*</sup>
-* Linux (for x86, x86_64, and armv7l architectures)
+* Linux (for x86, x86_64, armv7l, and arm64 architectures)
 
 <sup>*</sup> *Note for OS X / MAS target bundles: the `.app` bundle can only be signed when building on a host OS X platform.*
 

--- a/test/targets.js
+++ b/test/targets.js
@@ -38,8 +38,13 @@ test('validateListFromOptions does not take non-Array/String values', (t) => {
   t.end()
 })
 
-testMultiTarget('build for all available official targets', {all: true}, util.allPlatformArchCombosCount,
+testMultiTarget('build for all available official targets', {all: true, electronVersion: '1.8.0'},
+                util.allPlatformArchCombosCount,
                 'Packages should be generated for all possible platforms')
+testMultiTarget('build for all available official targets for a version without arm64 support',
+                {all: true},
+                util.allPlatformArchCombosCount - 1,
+                'Packages should be generated for all possible platforms (except arm64)')
 testMultiTarget('platform=all (one arch)', {arch: 'ia32', platform: 'all'}, 2,
                 'Packages should be generated for both 32-bit platforms')
 testMultiTarget('arch=all test (one platform)', {arch: 'all', platform: 'linux'}, 3,
@@ -59,6 +64,8 @@ util.packagerTest('fails with invalid platform', util.invalidOptionTest({
 }))
 
 testMultiTarget('invalid official combination', {arch: 'ia32', platform: 'darwin'}, 0, 'Package should not be generated for invalid official combination')
+testMultiTarget('platform=linux and arch=arm64 with a supported official Electron version', {arch: 'arm64', platform: 'linux', electronVersion: '1.8.0'}, 1, 'Package should be generated for arm64')
+testMultiTarget('platform=linux and arch=arm64 with an unsupported official Electron version', {arch: 'arm64', platform: 'linux'}, 0, 'Package should not be generated for arm64')
 testMultiTarget('unofficial arch', {arch: 'z80', platform: 'linux', download: {mirror: 'mirror'}}, 1,
                 'Package should be generated for non-standard arch from non-official mirror')
 testMultiTarget('unofficial platform', {arch: 'ia32', platform: 'minix', download: {mirror: 'mirror'}}, 1,

--- a/test/util.js
+++ b/test/util.js
@@ -36,7 +36,7 @@ function teardown () {
   })
 }
 
-exports.allPlatformArchCombosCount = 7
+exports.allPlatformArchCombosCount = 8
 
 exports.areFilesEqual = function areFilesEqual (file1, file2) {
   let buffer1, buffer2

--- a/usage.txt
+++ b/usage.txt
@@ -17,8 +17,8 @@ appname            the name of the app, if it needs to be different from the "pr
 all                equivalent to --platform=all --arch=all
 app-copyright      human-readable copyright line for the app
 app-version        release version to set for the app
-arch               all, or one or more of: ia32, x64, armv7l (comma-delimited if multiple). Defaults
-                   to the host arch
+arch               all, or one or more of: ia32, x64, armv7l, arm64 (comma-delimited if multiple).
+                   Defaults to the host arch
 asar               whether to package the source code within your app into an archive. You can either
                    pass --asar by itself to use the default configuration, OR use dot notation to
                    configure a list of sub-properties, e.g. --asar.unpackDir=sub_dir - do not use


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

With https://github.com/electron/electron/pull/10219 merged, ARM64 support is likely to be official starting with the Electron 1.8 release series. This adds basic official support for the arch, plus adds it to the platform/arch combinations when `all` is true or `platform=linux` and `arch=all` is set, and the specified version of Electron is 1.8.0 or above.
