### PR TITLE
Fix inferring `win32metadata.CompanyName` when author is an Object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* Inferring `win32metadata.CompanyName` from `author` in `package.json` when it's an Object (#718)
+
 ## [9.0.0] - 2017-08-23
 
 ### Added

--- a/infer.js
+++ b/infer.js
@@ -121,7 +121,13 @@ module.exports = function getMetadataFromPackageJSON (platforms, opts, dir, cb) 
 
     if (result.values.author) {
       debug(`Inferring win32metadata.CompanyName from author in ${result.source.author.src}`)
-      opts.win32metadata.CompanyName = parseAuthor(result.values.author).name
+      if (typeof result.values.author === 'string') {
+        opts.win32metadata.CompanyName = parseAuthor(result.values.author).name
+      } else if (result.values.author.name) {
+        opts.win32metadata.CompanyName = result.values.author.name
+      } else {
+        debug('Cannot infer win32metadata.CompanyName from author, no name found')
+      }
     }
 
     if (result.values['dependencies.electron']) {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Don't use `parse-author` when it's already an Object.

Fixes #718.