### PR TITLE
Clean up CLI options/docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+* CLI arguments with nonstandard argument values emit warnings (#722)
+
 ## [9.0.1] - 2017-09-02
 
 ### Fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 * CLI arguments with nonstandard argument values emit warnings (#722)
 
+### Deprecated
+
+* In the CLI, `--tmpdir=false` has been deprecated in favor of `--no-tmpdir` (#722)
+
 ## [9.0.1] - 2017-09-02
 
 ### Fixed

--- a/common.js
+++ b/common.js
@@ -51,6 +51,7 @@ function parseCLIArgs (argv) {
   }
 
   if (args.out === '') {
+    warning('Specifying --out= without a value is the same as the default value')
     args.out = null
   }
 
@@ -58,11 +59,13 @@ function parseCLIArgs (argv) {
 
   // asar: `Object` or `true`
   if (args.asar === 'true' || args.asar instanceof Array) {
+    warning('--asar does not take any arguments, it only has sub-properties (see --help)')
     args.asar = true
   }
 
   // osx-sign: `Object` or `true`
   if (args.osxSign === 'true') {
+    warning('--osx-sign does not take any arguments, it only has sub-properties (see --help)')
     args.osxSign = true
   }
 

--- a/common.js
+++ b/common.js
@@ -71,6 +71,7 @@ function parseCLIArgs (argv) {
 
   // tmpdir: `String` or `false`
   if (args.tmpdir === 'false') {
+    warning('--tmpdir=false is deprecated, use --no-tmpdir instead')
     args.tmpdir = false
   }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -69,7 +69,7 @@ test('CLI argument test: --protocol with a corresponding --protocol-name', (t) =
 
 test('CLI argument test: --protocol without a corresponding --protocol-name', (t) => {
   var args = common.parseCLIArgs(['--protocol=foo'])
-  t.deepEqual(args.protocols, undefined)
+  t.deepEqual(args.protocols, undefined, 'no protocols have been fully defined')
   t.end()
 })
 

--- a/usage.txt
+++ b/usage.txt
@@ -31,7 +31,6 @@ asar               whether to package the source code within your app into an ar
                    - unpackDir: unpacks the dir to the app.asar.unpacked directory whose names glob
                      pattern or exactly match this string. It's relative to the <sourcedir>.
 build-version      build version to set for the app
-deref-symlinks     whether symlinks should be dereferenced within the app source. Defaults to true.
 download           a list of sub-options to pass to electron-download. They are specified via dot
                    notation, e.g., --download.cache=/tmp/cache
                    Properties supported:
@@ -47,6 +46,7 @@ icon               the local path to an icon file to use as the icon for the app
 ignore             do not copy files into app whose filenames RegExp.match this string. See also:
                    https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#ignore
                    and --no-prune. Can be specified multiple times
+no-deref-symlinks  make sure symlinks are not dereferenced within the app source
 no-prune           do not prune devDependencies from the packaged app
 out                the dir to put the app into at the end. defaults to current working dir
 overwrite          if output directory for a platform already exists, replaces it rather than

--- a/usage.txt
+++ b/usage.txt
@@ -37,7 +37,7 @@ download           a list of sub-options to pass to electron-download. They are 
                    - cache: directory of cached Electron downloads. Defaults to `$HOME/.electron`
                    - mirror: alternate URL to download Electron zips
                    - strictSSL: whether SSL certs are required to be valid when downloading
-                     Electron. Defaults to true, use --download.strictSSL=false to disable checks.
+                     Electron. Defaults to true, use --no-download.strictSSL to disable checks.
 electron-version   the version of Electron that is being packaged, see
                    https://github.com/electron/electron/releases
 extra-resource     a file to copy into the app's resources directory

--- a/usage.txt
+++ b/usage.txt
@@ -44,15 +44,16 @@ electron-version   the version of Electron that is being packaged, see
 extra-resource     a file to copy into the app's resources directory
 icon               the local path to an icon file to use as the icon for the app.
                    Note: Format depends on platform.
-ignore             do not copy files into app whose filenames regex .match this string. See also:
+ignore             do not copy files into app whose filenames RegExp.match this string. See also:
                    https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#ignore
-                   and --no-prune.
+                   and --no-prune. Can be specified multiple times
 no-prune           do not prune devDependencies from the packaged app
 out                the dir to put the app into at the end. defaults to current working dir
 overwrite          if output directory for a platform already exists, replaces it rather than
                    skipping it
 package-manager    the package manager to use when pruning devDependencies. Supported package
-                   managers: npm (default), cnpm, yarn
+                   managers: npm (default), cnpm, yarn. Specify --no-package-manager to prune
+                   without using a package manager
 platform           all, or one or more of: darwin, linux, mas, win32 (comma-delimited if multiple).
                    Defaults to the host platform
 quiet              Do not print informational or warning messages

--- a/usage.txt
+++ b/usage.txt
@@ -57,7 +57,7 @@ package-manager    the package manager to use when pruning devDependencies. Supp
 platform           all, or one or more of: darwin, linux, mas, win32 (comma-delimited if multiple).
                    Defaults to the host platform
 quiet              Do not print informational or warning messages
-tmpdir             temp directory. Defaults to system temp directory, use --tmpdir=false to disable
+tmpdir             temp directory. Defaults to system temp directory, use --no-tmpdir to disable
                    use of a temporary directory.
 
 * darwin/mas target platforms only *


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* Deprecate/warn when using nonstandard CLI options. I'm doing this because I think I'm going to move towards yargs-parser (which is more maintained and looks like it will let me get rid of some of the CLI handling code)
* Update some CLI docs for clarity