### PR TITLE
Add target arch API

### DIFF
--- a/targets.js
+++ b/targets.js
@@ -72,8 +72,18 @@ function warnIfAllNotSpecified (opts, message) {
   }
 }
 
+function hostArch () {
+  /* istanbul ignore if */
+  if (process.arch === 'arm' && process.config.variables.arm_version === '7') {
+    return 'armv7l'
+  }
+
+  return process.arch
+}
+
 module.exports = {
   createPlatformArchPairs: createPlatformArchPairs,
+  hostArch: hostArch,
   officialArchs: officialArchs,
   officialPlatformArchCombos: officialPlatformArchCombos,
   officialPlatforms: officialPlatforms,
@@ -84,8 +94,16 @@ module.exports = {
   validateListFromOptions: function validateListFromOptions (opts, name) {
     if (opts.all) return Array.from(supported[name].values())
 
-    let list = opts[name] || process[name]
-    if (list === 'all') return Array.from(supported[name].values())
+    let list = opts[name]
+    if (!list) {
+      if (name === 'arch') {
+        list = hostArch()
+      } else {
+        list = process[name]
+      }
+    } else if (list === 'all') {
+      return Array.from(supported[name].values())
+    }
 
     if (!Array.isArray(list)) {
       if (typeof list === 'string') {

--- a/targets.js
+++ b/targets.js
@@ -82,6 +82,14 @@ function hostArch () {
 }
 
 module.exports = {
+  allOfficialArchsForPlatformAndVersion: function allOfficialArchsForPlatformAndVersion (platform, electronVersion) {
+    const archs = officialPlatformArchCombos[platform]
+    if (platform === 'linux' && !officialLinuxARM64BuildExists({electronVersion: electronVersion})) {
+      return archs.filter((arch) => arch !== 'arm64')
+    }
+
+    return archs
+  },
   createPlatformArchPairs: createPlatformArchPairs,
   hostArch: hostArch,
   officialArchs: officialArchs,

--- a/test/targets.js
+++ b/test/targets.js
@@ -30,6 +30,24 @@ function testCombinations (testcaseDescription, arch, platform) {
                   'Packages should be generated for all combinations of specified archs and platforms')
 }
 
+test('allOfficialArchsForPlatformAndVersion is undefined for unknown platforms', (t) => {
+  t.equal(targets.allOfficialArchsForPlatformAndVersion('unknown', '1.0.0'), undefined)
+  t.end()
+})
+
+test('allOfficialArchsForPlatformAndVersion returns the correct arches for a known platform', (t) => {
+  t.deepEqual(targets.allOfficialArchsForPlatformAndVersion('darwin', '1.0.0'), ['x64'])
+  t.end()
+})
+
+test('allOfficialArchsForPlatformAndVersion returns arm64 when the correct version is specified', (t) => {
+  t.notEqual(targets.allOfficialArchsForPlatformAndVersion('linux', '1.8.0').indexOf('arm64'), -1,
+             'should be found when version is >= 1.8.0')
+  t.equal(targets.allOfficialArchsForPlatformAndVersion('linux', '1.7.0').indexOf('arm64'), -1,
+          'should not be found when version is < 1.8.0')
+  t.end()
+})
+
 test('validateListFromOptions does not take non-Array/String values', (t) => {
   targets.supported.digits = new Set(['64', '65'])
   t.notOk(targets.validateListFromOptions({digits: 64}, 'digits') instanceof Array,


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Adds two API functions in `target.js`:

* `hostArch`, which is the same function as `electronHostArch` in Electron Forge and is used internally as well
* `allOfficialArchsForPlatformAndVersion`, made specifically for Forge (https://github.com/electron-userland/electron-forge/pull/320). It might be nice to eventually use it internally, but it would take a nontrivial refactor.