### PR TITLE
Replace minimist & camelize with yargs-parser

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,12 +1,10 @@
 'use strict'
 
 const asar = require('asar')
-const camelize = require('camelize')
 const debug = require('debug')('electron-packager')
 const download = require('electron-download')
 const fs = require('fs-extra')
 const ignore = require('./ignore')
-const minimist = require('minimist')
 const os = require('os')
 const path = require('path')
 const pruneModules = require('./prune').pruneModules
@@ -14,9 +12,10 @@ const sanitize = require('sanitize-filename')
 const semver = require('semver')
 const series = require('run-series')
 const targets = require('./targets')
+const yargs = require('yargs-parser')
 
 function parseCLIArgs (argv) {
-  var args = minimist(argv, {
+  var args = yargs(argv, {
     boolean: [
       'all',
       'deref-symlinks',
@@ -38,8 +37,6 @@ function parseCLIArgs (argv) {
 
   args.dir = args._[0]
   args.name = args._[1]
-
-  args = camelize(args)
 
   var protocolSchemes = [].concat(args.protocol || [])
   var protocolNames = [].concat(args.protocolName || [])

--- a/package.json
+++ b/package.json
@@ -18,14 +18,12 @@
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
     "asar": "^0.13.0",
-    "camelize": "^1.0.0",
     "debug": "^3.0.0",
     "electron-download": "^4.0.0",
     "electron-osx-sign": "^0.4.1",
     "extract-zip": "^1.0.3",
     "fs-extra": "^4.0.0",
     "get-package-info": "^1.0.0",
-    "minimist": "^1.1.1",
     "parse-author": "^2.0.0",
     "pify": "^3.0.0",
     "plist": "^2.0.0",
@@ -34,7 +32,8 @@
     "resolve": "^1.1.6",
     "run-series": "^1.1.1",
     "sanitize-filename": "^1.6.0",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "yargs-parser": "^7.0.0"
   },
   "devDependencies": {
     "buffer-equal": "^1.0.0",


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`minimist` is unmaintained, `yargs-parser` is maintained and also compatible with `minimist`'s API. It also has its own camel-case implementation so we can get rid of `camelize` as well.