### PR TITLE
Cache node_modules instead of the NPM cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ matrix:
 cache:
 - apt: true
 - directories:
-  - "$HOME/.npm"
+  - "node_modules"
   - "$HOME/.electron"
 before_install: test/ci/before_install.sh
+install:
+- npm install
+- npm update
 after_success: npm run coveralls
 branches:
   only:

--- a/test/ci/appveyor.yml
+++ b/test/ci/appveyor.yml
@@ -11,7 +11,7 @@ matrix:
   allow_failures:
   - nodejs_version: "9"
 cache:
-- '%APPDATA%\npm-cache'
+- 'node_modules'
 - '%USERPROFILE%\.electron'
 branches:
   only:
@@ -22,6 +22,7 @@ install:
 - npm install -g npm@4
 - set PATH=%APPDATA%\npm;%PATH%
 - npm install
+- npm update
 
 test_script:
 - node --version


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

Hopefully this drops the CI cache size (and build time) while also making sure that it gets tested with the latest dependencies.