### PR TITLE
Moved hostArch() earlier in validateListFromOptions()

### DIFF
--- a/targets.js
+++ b/targets.js
@@ -102,13 +102,14 @@ module.exports = {
   validateListFromOptions: function validateListFromOptions (opts, name) {
     if (opts.all) return Array.from(supported[name].values())
 
-    let list = opts[name]
+    let list
+    if (name === 'arch') {
+      list = hostArch()
+    } else {
+      list = opts[name]
+    }
     if (!list) {
-      if (name === 'arch') {
-        list = hostArch()
-      } else {
-        list = process[name]
-      }
+      list = process[name]
     } else if (list === 'all') {
       return Array.from(supported[name].values())
     }
@@ -128,7 +129,6 @@ module.exports = {
         return unsupportedListOption(name, value, supported[name])
       }
     }
-
     return list
   }
 }


### PR DESCRIPTION

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR is in response to atom/atom#15431.  When I tried to build Atom on my Chromebook running Arch Linux ARM, the automatic trigger detecting armv7l was not running because a value already existed for the arch.  This change moves the hostArch() function before the list assignment to catch this case.

I did not add documentation for this change because it is sufficiently simple that I think additional comments would not be helpful.  Similarly, I did not add tests.  I confess I don't know how to run the test suite, but the code did pass one important test -- when I ran it, the correct architecture was detected and
a package was built!