### PR TITLE
Don't create yarn.lock when pruning with Yarn

### DIFF
--- a/prune.js
+++ b/prune.js
@@ -12,7 +12,7 @@ function pruneCommand (packageManager) {
     case 'cnpm':
       return `${packageManager} prune --production`
     case 'yarn':
-      return `${packageManager} install --production --no-bin-links`
+      return `${packageManager} install --production --no-bin-links --no-lockfile`
   }
 }
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #764.