### PR TITLE
Fix protocols API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -323,21 +323,15 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 - `entitlements` (*String*): The path to the 'parent' entitlements.
 - `entitlements-inherit` (*String*): The path to the 'child' entitlements.
 
-##### `protocol`
+##### `protocols`
 
-*Array* of *String*​s
+*Array* of *Object*​s
 
-The URL protocol scheme(s) to associate the app with. For example, specifying
+In each Object should have:
+- `name` (*String*): The descriptive name of the URL protocol scheme(s). Maps to the `CFBundleURLName` metadata property.
+- `schemes` (*Array* of *String*s): The URL protocol scheme(s) to associate the app with. For example, specifying
 `myapp` would cause URLs such as `myapp://path` to be opened with the app. Maps
-to the `CFBundleURLSchemes` metadata property. This option requires a
-corresponding `protocol-name` option to be specified.
-
-##### `protocolName`
-
-*Array* of *String*​s
-
-The descriptive name(s) of the URL protocol scheme(s) specified via the `protocol`
-option. Maps to the `CFBundleURLName` metadata property.
+to the `CFBundleURLSchemes` metadata property.
 
 #### Windows targets only
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -327,11 +327,14 @@ If present, signs OS X target apps when the host platform is OS X and XCode is i
 
 *Array* of *Object*​s
 
-In each Object should have:
-- `name` (*String*): The descriptive name of the URL protocol scheme(s). Maps to the `CFBundleURLName` metadata property.
-- `schemes` (*Array* of *String*s): The URL protocol scheme(s) to associate the app with. For example, specifying
-`myapp` would cause URLs such as `myapp://path` to be opened with the app. Maps
-to the `CFBundleURLSchemes` metadata property.
+One or more URL protocols associated with the Electron app.
+
+Each *Object* is required to have the following properties:
+
+- `name` (*String*): The descriptive name. Maps to the `CFBundleURLName` metadata property.
+- `schemes` (*Array* of *String*​s): One or more protocol schemes associated with the app. For
+  example, specifying `myapp` would cause URLs such as `myapp://path` to be opened with the app.
+  Maps to the `CFBundleURLSchemes` metadata property.
 
 #### Windows targets only
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

When useing `electron-packager` pragmatically for OS X packaging, `protocol` and `protocolName` option will not work for setting OS X URL protocol schemes.

Instead use `protocols` option described in [mac.js#L34](https://github.com/electron-userland/electron-packager/blob/3ce4907d7645578e1ba24754d86ed531b0671112/mac.js#L34), [test/darwin.js#L262](https://github.com/electron-userland/electron-packager/blob/3ce4907d7645578e1ba24754d86ed531b0671112/test/darwin.js#L262) and used in [mac.js#L168](https://github.com/electron-userland/electron-packager/blob/31e1e98634f453a566bb424d04c220230ffdd238/mac.js#L168) will produce the right plist file.

Closes #643.
