### PR TITLE
Add extraResource custom subpath support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -153,10 +153,14 @@ valid versions. If omitted, it will use the version of the nearest local install
 
 ##### `extraResource`
 
-*String* or *Array* of *String*s
+*Object*, *String* or *Array* of *String*s and/or *Object*s
 
 One or more files to be copied directly into the app's `Contents/Resources` directory for OS X
 target platforms, and the `resources` directory for other target platforms.
+
+A Object defines the files source with a custom destination, by the following properties
+- `from` (*String*): The source file
+- `to` (*String*): Destination path for the new file inlclusive the filename, relative from the `resources` directory.
 
 ##### `executableName`
 

--- a/platform.js
+++ b/platform.js
@@ -157,7 +157,17 @@ class App {
     if (!Array.isArray(extraResources)) extraResources = [extraResources]
 
     return Promise.all(extraResources.map(
-      resource => fs.copy(resource, path.resolve(this.stagingPath, this.resourcesDir, path.basename(resource)))
+      resource => {
+        if ((typeof resource) === 'object') {
+          if (resource.hasOwnProperty('from') && resource.hasOwnProperty('to')) {
+            fs.copy(resource.from, path.resolve(this.stagingPath, this.resourcesDir, resource.to))
+          } else {
+            return Promise.reject(new Error('ExtraResource object is invalid'))
+          }
+        } else {
+          fs.copy(resource, path.resolve(this.stagingPath, this.resourcesDir, path.basename(resource)))
+        }
+      }
     ))
   }
 

--- a/prune.js
+++ b/prune.js
@@ -12,7 +12,7 @@ function pruneCommand (packageManager) {
     case 'cnpm':
       return `${packageManager} prune --production`
     case 'yarn':
-      return `${packageManager} install --production --no-bin-links --no-lockfile`
+      return `${packageManager} install --production --no-bin-links --no-lockfile --force`
   }
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -250,24 +250,51 @@ function createExtraResourceStringTest (t, opts, platform) {
     .then(equal => t.true(equal, 'resource file data1.txt should match'))
 }
 
+function createExtraResourceObjectTest (t, opts, platform) {
+  const extra1Base = 'data1.txt'
+  const extra1Path = path.join(__dirname, 'fixtures', extra1Base)
+  const extra1Object = {
+    from: extra1Path,
+    to: 'test/data1.txt'
+  }
+
+  opts.name = 'extraResourceObjectTest'
+  opts.dir = util.fixtureSubdir('basic')
+  opts.out = 'dist'
+  opts.platform = platform
+  opts.extraResource = extra1Object
+
+  return util.packageAndEnsureResourcesPath(t, opts)
+    .then(resourcesPath => {
+      return util.areFilesEqual(extra1Path, path.join(resourcesPath, 'test', extra1Base))
+    })
+    .then(equal => t.true(equal, 'resource file data1.txt should match'))
+}
+
 function createExtraResourceArrayTest (t, opts, platform) {
   const extra1Base = 'data1.txt'
   const extra1Path = path.join(__dirname, 'fixtures', extra1Base)
   const extra2Base = 'extrainfo.plist'
   const extra2Path = path.join(__dirname, 'fixtures', extra2Base)
+  const extra3Object = {
+    from: extra1Path,
+    to: 'test/data1.txt'
+  }
 
   opts.name = 'extraResourceArrayTest'
   opts.dir = util.fixtureSubdir('basic')
   opts.out = 'dist'
   opts.platform = platform
-  opts.extraResource = [extra1Path, extra2Path]
+  opts.extraResource = [extra1Path, extra2Path, extra3Object]
 
   let extra1DistPath
+  let extra1CustomDistPath
   let extra2DistPath
 
   return util.packageAndEnsureResourcesPath(t, opts)
     .then(resourcesPath => {
       extra1DistPath = path.join(resourcesPath, extra1Base)
+      extra1CustomDistPath = path.join(resourcesPath, 'test', extra1Base)
       extra2DistPath = path.join(resourcesPath, extra2Base)
       return fs.pathExists(extra1DistPath)
     }).then(exists => {
@@ -279,11 +306,15 @@ function createExtraResourceArrayTest (t, opts, platform) {
     }).then(exists => {
       t.true(exists, 'resource file extrainfo.plist exists')
       return util.areFilesEqual(extra2Path, extra2DistPath)
-    }).then(equal => t.true(equal, 'resource file extrainfo.plist should match'))
+    }).then(equal => {
+      t.true(equal, 'resource file extrainfo.plist should match')
+      return util.areFilesEqual(extra1Path, extra1CustomDistPath)
+    }).then(equal => t.true(equal, 'resource file data1.txt in custom destination folder should match'))
 }
 
 for (const platform of ['darwin', 'linux']) {
   util.testSinglePlatform(`extraResource test: string (${platform})`, createExtraResourceStringTest, platform)
+  util.testSinglePlatform(`extraResource test: object (${platform})`, createExtraResourceObjectTest, platform)
   util.testSinglePlatform(`extraResource test: array (${platform})`, createExtraResourceArrayTest, platform)
 }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [x] The test suite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Added a configuration object for ExtraResource, it allows to define a destination inside the resources folder or to rename the file. This is also in the feature set of `electron-builder` and is applicable to use cases where e.g you need to pick one certain DLL from within devDependencies to your resource folder.