### PR TITLE
Replace coveralls with codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,13 @@ install:
 - npm install
 - npm update
 before_script: test/ci/_before_script.js
-after_success: npm run coveralls
+after_success: npm run codecov
 branches:
   only:
   - master
   - /^v\d+\.\d+\.\d+/
 env:
   global:
-    # coveralls token
-    - secure: hG3cs8/tOGTa8IPewVuahcp1f8gwsk/rX7ReUBPag6cdZdJpkbjzxp8R97mhhCrFOP/fvX8zAbCelXvvhME/mjZTFgzSNHLBL/SJreHP5m2B1yxXkroiQFu1qwewvzzKmfcs5W1CD8J8WbJuBk9zozDQG9c1OxTaK87tBGh1xik=
     # prevent wine popup dialogs about installing additional packages
     - WINEDLLOVERRIDES="mscoree,mshtml="
     - WINEDEBUG="-all"

--- a/ignore.js
+++ b/ignore.js
@@ -75,7 +75,6 @@ function userIgnoreFilter (opts) {
 
     let name = file.split(path.resolve(opts.dir))[1]
 
-    /* istanbul ignore if */
     if (path.sep === '\\') {
       // convert slashes so unix-format ignores work
       name = name.replace(/\\/g, '/')

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "ava": "^0.24.0",
     "buffer-equal": "^1.0.0",
-    "coveralls": "^3.0.0",
+    "codecov": "^3.0.0",
     "eslint": "^4.1.0",
     "eslint-config-standard": "^10.0.0",
     "eslint-plugin-ava": "^4.3.0",
@@ -57,7 +57,7 @@
     "node": ">= 4.0"
   },
   "scripts": {
-    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "codecov": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "lint": "eslint .",
     "test": "npm run lint && nyc ava test/index.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Package your [Electron](http://electron.atom.io) app into OS-specific bundles (`
 
 [![Travis CI Build Status](https://travis-ci.org/electron-userland/electron-packager.svg?branch=master)](https://travis-ci.org/electron-userland/electron-packager)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/m51mlf6ntd138555/branch/master?svg=true)](https://ci.appveyor.com/project/electron-userland/electron-packager)
-[![Coverage Status](https://coveralls.io/repos/github/electron-userland/electron-packager/badge.svg?branch=master)](https://coveralls.io/github/electron-userland/electron-packager?branch=master)
+[![Coverage Status](https://codecov.io/gh/electron-userland/electron-packager/branch/master/graph/badge.svg)](https://codecov.io/gh/electron-userland/electron-packager)
 [![Dependency Status](https://dependencyci.com/github/electron-userland/electron-packager/badge)](https://dependencyci.com/github/electron-userland/electron-packager)
 
 [Supported Platforms](#supported-platforms) |

--- a/test/ci/appveyor.yml
+++ b/test/ci/appveyor.yml
@@ -29,5 +29,6 @@ test_script:
 - npm --version
 - node test/ci/_before_script.js
 - npm test
+- npm run codecov
 
 build: off


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

codecov works with both Travis CI *and* AppVeyor, so certain Windows-specific code can be covered.