### PR TITLE
Add support for official MIPS64EL arch on Linux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,15 @@
 
 [Unreleased]: https://github.com/electron-userland/electron-packager/compare/v10.1.2...master
 
+### Added
+
+* `linux` platform, `mips64el` arch builds (Electron 1.8.2-beta.5 and above) (#800)
+
+### Changed
+
+* `all` or `platform=linux, arch=all` now include `arch=mips64el` if the Electron version specified
+  is 1.8.2-beta.5 or above (#800)
+
 ## [10.1.2] - 2018-01-26
 
 [10.1.2]: https://github.com/electron-userland/electron-packager/compare/v10.1.1...v10.1.2

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,7 +90,8 @@ The release version of the application. By default the `version` property in the
 
 *String* (default: the arch of the host computer running Node)
 
-Allowed values: `ia32`, `x64`, `armv7l`, `arm64` _(Electron 1.8.0 and above)_, `all`
+Allowed values: `ia32`, `x64`, `armv7l`, `arm64` _(Electron 1.8.0 and above)_, `mips64el`
+_(Electron 1.8.2-beta.5 and above)_, `all`
 
 The target system architecture(s) to build for.
 Not required if the [`all`](#all) option is set.

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ It generates executables/bundles for the following **target** platforms:
 
 * Windows (also known as `win32`, for both 32/64 bit)
 * OS X (also known as `darwin`) / [Mac App Store](http://electron.atom.io/docs/v0.36.0/tutorial/mac-app-store-submission-guide/) (also known as `mas`)<sup>*</sup>
-* Linux (for x86, x86_64, armv7l, and arm64 architectures)
+* Linux (for x86, x86_64, armv7l, arm64, and mips64el architectures)
 
 <sup>*</sup> *Note for OS X / MAS target bundles: the `.app` bundle can only be signed when building on a host OS X platform.*
 

--- a/test/_util.js
+++ b/test/_util.js
@@ -44,7 +44,7 @@ function testSinglePlatform (name, testFunction, testFunctionArgs, parallel) {
 }
 
 module.exports = {
-  allPlatformArchCombosCount: 8,
+  allPlatformArchCombosCount: 9,
   areFilesEqual: function areFilesEqual (file1, file2) {
     let buffer1, buffer2
 

--- a/test/targets.js
+++ b/test/targets.js
@@ -45,6 +45,13 @@ test('allOfficialArchsForPlatformAndVersion returns arm64 when the correct versi
        'should not be found when version is < 1.8.0')
 })
 
+test('allOfficialArchsForPlatformAndVersion returns mips64el when the correct version is specified', t => {
+  t.not(targets.allOfficialArchsForPlatformAndVersion('linux', '1.8.2').indexOf('mips64el'), -1,
+        'should be found when version is >= 1.8.2-beta.5')
+  t.is(targets.allOfficialArchsForPlatformAndVersion('linux', '1.8.0').indexOf('mips64el'), -1,
+       'should not be found when version is < 1.8.2-beta.5')
+})
+
 test('validateListFromOptions does not take non-Array/String values', t => {
   targets.supported.digits = new Set(['64', '65'])
   t.false(targets.validateListFromOptions({digits: 64}, 'digits') instanceof Array,
@@ -63,13 +70,13 @@ test('validateListFromOptions works for armv7l host and target arch', t => {
   sandbox.restore()
 })
 
-testMultiTarget('build for all available official targets', {all: true, electronVersion: '1.8.0'},
+testMultiTarget('build for all available official targets', {all: true, electronVersion: '1.8.2'},
                 util.allPlatformArchCombosCount,
                 'Packages should be generated for all possible platforms')
-testMultiTarget('build for all available official targets for a version without arm64 support',
+testMultiTarget('build for all available official targets for a version without arm64 or mips64el support',
                 {all: true},
-                util.allPlatformArchCombosCount - 1,
-                'Packages should be generated for all possible platforms (except arm64)')
+                util.allPlatformArchCombosCount - 2,
+                'Packages should be generated for all possible platforms (except arm64 and mips64el)')
 testMultiTarget('platform=all (one arch)', {arch: 'ia32', platform: 'all'}, 2,
                 'Packages should be generated for both 32-bit platforms')
 testMultiTarget('arch=all test (one platform)', {arch: 'all', platform: 'linux'}, 3,
@@ -125,6 +132,8 @@ test('hostArch cannot determine ARM version', t => {
 testMultiTarget('invalid official combination', {arch: 'ia32', platform: 'darwin'}, 0, 'Package should not be generated for invalid official combination')
 testMultiTarget('platform=linux and arch=arm64 with a supported official Electron version', {arch: 'arm64', platform: 'linux', electronVersion: '1.8.0'}, 1, 'Package should be generated for arm64')
 testMultiTarget('platform=linux and arch=arm64 with an unsupported official Electron version', {arch: 'arm64', platform: 'linux'}, 0, 'Package should not be generated for arm64')
+testMultiTarget('platform=linux and arch=mips64el with a supported official Electron version', {arch: 'mips64el', platform: 'linux', electronVersion: '1.8.2-beta.5'}, 1, 'Package should be generated for mips64el')
+testMultiTarget('platform=linux and arch=mips64el with an unsupported official Electron version', {arch: 'mips64el', platform: 'linux'}, 0, 'Package should not be generated for mips64el')
 testMultiTarget('unofficial arch', {arch: 'z80', platform: 'linux', download: {mirror: 'mirror'}}, 1,
                 'Package should be generated for non-standard arch from non-official mirror')
 testMultiTarget('unofficial platform', {arch: 'ia32', platform: 'minix', download: {mirror: 'mirror'}}, 1,

--- a/usage.txt
+++ b/usage.txt
@@ -17,8 +17,8 @@ appname            the name of the app, if it needs to be different from the "pr
 all                equivalent to --platform=all --arch=all
 app-copyright      human-readable copyright line for the app
 app-version        release version to set for the app
-arch               all, or one or more of: ia32, x64, armv7l, arm64 (comma-delimited if multiple).
-                   Defaults to the host arch
+arch               all, or one or more of: ia32, x64, armv7l, arm64, mips64el (comma-delimited if
+                   multiple). Defaults to the host arch
 asar               whether to package the source code within your app into an archive. You can either
                    pass --asar by itself to use the default configuration, OR use dot notation to
                    configure a list of sub-properties, e.g. --asar.unpackDir=sub_dir - do not use


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This arch is available with official Electron releases starting with [Electron 1.8.2-beta.5](https://github.com/electron/electron/releases/tag/v1.8.2-beta.5).

This is a breaking change, since the behavior of the `all` option changes.