### PR TITLE
Execute hooks in series as per pre-v10 releases

### DIFF
--- a/common.js
+++ b/common.js
@@ -149,7 +149,11 @@ module.exports = {
       return Promise.resolve()
     }
 
-    return Promise.all(hooks.map(hookFn => pify(hookFn).apply(this, args)))
+    const promisified = hooks.map(hookFn => pify(hookFn).bind(this, ...args))
+
+    return promisified.reduce((previous, current) => {
+      return previous.then(() => current())
+    }, Promise.resolve())
   },
 
   info: info,

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -7,23 +7,51 @@ const util = require('./_util')
 function createHookTest (hookName) {
   // 2 packages will be built during this test
   util.packagerTest(`platform=all test (one arch) (${hookName} hook)`, (t, opts) => {
-    let hookCalled = false
+    let fn1 = false
+    let fn2 = false
+    let fn3 = false
+
     opts.dir = util.fixtureSubdir('basic')
     opts.electronVersion = config.version
     opts.arch = 'ia32'
     opts.platform = 'all'
 
-    opts[hookName] = [(buildPath, electronVersion, platform, arch, callback) => {
-      hookCalled = true
-      t.is(electronVersion, opts.electronVersion, `${hookName} electronVersion should be the same as the options object`)
-      t.is(arch, opts.arch, `${hookName} arch should be the same as the options object`)
-      callback()
-    }]
+    opts[hookName] = [
+      (buildPath, electronVersion, platform, arch, callback) => {
+        fn1 = false
+        fn2 = false
+        fn3 = false
+        callback()
+      },
+      (buildPath, electronVersion, platform, arch, callback) => {
+        t.is(electronVersion, opts.electronVersion, `${hookName} electronVersion should be the same as the options object`)
+        t.is(arch, opts.arch, `${hookName} arch should be the same as the options object`)
+        setTimeout(() => {
+          fn1 = true
+          callback()
+        })
+      },
+      (buildPath, electronVersion, platform, arch, callback) => {
+        t.true(fn1, 'second hook executes after the first')
+        t.false(fn3, 'second hook executes before the third')
+        setTimeout(() => {
+          fn2 = true
+          callback()
+        })
+      },
+      (buildPath, electronVersion, platform, arch, callback) => {
+        t.true(fn1 && fn2, 'third hook executes after the first and second')
+        setTimeout(() => {
+          fn3 = true
+          callback()
+        })
+      }
+    ]
 
     return packager(opts)
       .then(finalPaths => {
         t.is(finalPaths.length, 2, 'packager call should resolve with expected number of paths')
-        t.true(hookCalled, `${hookName} methods should have been called`)
+        t.true(fn1 && fn2 && fn3, `${hookName} methods should have been called`)
         return util.verifyPackageExistence(finalPaths)
       }).then(exists => t.deepEqual(exists, [true, true], 'Packages should be generated for both 32-bit platforms'))
   })


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

Since v10, the functions provided to `afterCopy`, `afterExtract` and `afterPrune` no longer execute in series. In some cases, this behaviour is desirable since one hook may effect changes that another hook assumes have already happened. I couldn't see anything about this change in the release notes, so this PR restores that behaviour whilst still using Promises internally.

If this change is welcome, could someone please give me some pointers getting the unit tests passing? I'm having a hard time, either seeing intermittent failures on the sequential ordering assertions (presumably because the `packagerTest` builds two packages), or the following:

```
  platform=all test (one arch) (afterPrune hook)

  Rejected promise returned by test. Reason:

  Error {
    cmd: 'npm prune --production',
    code: 1,
    killed: false,
    signal: null,
    message: `Command failed: npm prune --production␊
    npm WARN @4.99.101 No description␊
    npm WARN @4.99.101 No repository field.␊
    npm WARN @4.99.101 No license field.␊
    ␊
    npm ERR! May not delete: /private/var/folders/nz/s1gw0mtj4jq8jqc7w2p090tr0000gn/T/75089d8c4e4d0acbb0bcbe90f07b7de5/electron-packager/linux-ia32/packagerTest-linux-ia32/resources/app/node_modules/.bin␊
    ␊
    npm ERR! A complete log of this run can be found in:␊
    npm ERR!     /Users/username/.npm/_logs/2018-03-16T16_58_32_665Z-debug.log␊
    `,
  }
```