### PR TITLE
Add a utility function to execute hooks serially

### DIFF
--- a/common.js
+++ b/common.js
@@ -2,7 +2,6 @@
 
 const os = require('os')
 const path = require('path')
-const pify = require('pify')
 const sanitize = require('sanitize-filename')
 const yargs = require('yargs-parser')
 
@@ -143,14 +142,6 @@ module.exports = {
   generateFinalBasename: generateFinalBasename,
   generateFinalPath: generateFinalPath,
   sanitizeAppName: sanitizeAppName,
-
-  promisifyHooks: function promisifyHooks (hooks, args) {
-    if (!hooks || !Array.isArray(hooks)) {
-      return Promise.resolve()
-    }
-
-    return Promise.all(hooks.map(hookFn => pify(hookFn).apply(this, args)))
-  },
 
   info: info,
   warning: warning

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,32 @@ An array of functions to be called after your app directory has been copied to a
 - `arch` (*String*): The target architecture you are packaging for
 - `callback` (*Function*): Must be called once you have completed your actions
 
+By default, the functions are called in parallel (via
+[`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)).
+If you need the functions called serially, there is a utility function provided:
+
+```javascript
+const packager = require('electron-packager')
+const serialHooks = require('electron-packager/hooks').serialHooks
+
+packager({
+  // ...
+  afterCopy: [serialHooks([
+    (buildPath, electronVersion, platform, arch, callback) => {
+      setTimeout(() => {
+        console.log('first function')
+        callback()
+      }, 1000)
+    },
+    (buildPath, electronVersion, platform, arch, callback) => {
+      console.log('second function')
+      callback()
+    }
+  ])],
+  // ...
+})
+```
+
 ##### `afterExtract`
 
 *Array of Functions*
@@ -52,6 +78,32 @@ An array of functions to be called after Electron has been extracted to a tempor
 - `platform` (*String*): The target platform you are packaging for
 - `arch` (*String*): The target architecture you are packaging for
 - `callback` (*Function*): Must be called once you have completed your actions
+
+By default, the functions are called in parallel (via
+[`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)).
+If you need the functions called serially, there is a utility function provided:
+
+```javascript
+const packager = require('electron-packager')
+const serialHooks = require('electron-packager/hooks').serialHooks
+
+packager({
+  // ...
+  afterExtract: [serialHooks([
+    (buildPath, electronVersion, platform, arch, callback) => {
+      setTimeout(() => {
+        console.log('first function')
+        callback()
+      }, 1000)
+    },
+    (buildPath, electronVersion, platform, arch, callback) => {
+      console.log('second function')
+      callback()
+    }
+  ])],
+  // ...
+})
+```
 
 ##### `afterPrune`
 
@@ -67,6 +119,32 @@ in the temporary directory.  Each function is called with five parameters:
 - `callback` (*Function*): Must be called once you have completed your actions
 
 **NOTE:** None of these functions will be called if the `prune` option is `false`.
+
+By default, the functions are called in parallel (via
+[`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)).
+If you need the functions called serially, there is a utility function provided:
+
+```javascript
+const packager = require('electron-packager')
+const serialHooks = require('electron-packager/hooks').serialHooks
+
+packager({
+  // ...
+  afterPrune: [serialHooks([
+    (buildPath, electronVersion, platform, arch, callback) => {
+      setTimeout(() => {
+        console.log('first function')
+        callback()
+      }, 1000)
+    },
+    (buildPath, electronVersion, platform, arch, callback) => {
+      console.log('second function')
+      callback()
+    }
+  ])],
+  // ...
+})
+```
 
 ##### `all`
 

--- a/hooks.js
+++ b/hooks.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const pify = require('pify')
+
+module.exports = {
+  promisifyHooks: function promisifyHooks (hooks, args) {
+    if (!hooks || !Array.isArray(hooks)) {
+      return Promise.resolve()
+    }
+
+    return Promise.all(hooks.map(hookFn => pify(hookFn).apply(this, args)))
+  },
+  serialHooks: function serialHooks (hooks) {
+    return function () {
+      const args = Array.prototype.splice.call(arguments, 0, arguments.length - 1)
+      const done = arguments[arguments.length - 1]
+      let result = Promise.resolve()
+      for (const hook of hooks) {
+        result = result.then(() => hook.apply(this, args))
+      }
+
+      return result.then(() => done()) // eslint-disable-line promise/no-callback-in-promise
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const download = require('./download')
 const extract = require('extract-zip')
 const fs = require('fs-extra')
 const getMetadataFromPackageJSON = require('./infer')
+const hooks = require('./hooks')
 const ignore = require('./ignore')
 const metadata = require('./package.json')
 const nodeify = require('nodeify')
@@ -71,7 +72,7 @@ class Packager {
   extractElectronZip (comboOpts, zipPath, buildDir) {
     debug(`Extracting ${zipPath} to ${buildDir}`)
     return pify(extract)(zipPath, { dir: buildDir })
-      .then(() => common.promisifyHooks(this.opts.afterExtract, [buildDir, comboOpts.electronVersion, comboOpts.platform, comboOpts.arch]))
+      .then(() => hooks.promisifyHooks(this.opts.afterExtract, [buildDir, comboOpts.electronVersion, comboOpts.platform, comboOpts.arch]))
   }
 
   createApp (comboOpts, zipPath) {

--- a/platform.js
+++ b/platform.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const pify = require('pify')
 
+const hooks = require('./hooks')
 const ignore = require('./ignore')
 const pruneModules = require('./prune').pruneModules
 
@@ -101,7 +102,7 @@ class App {
     return fs.copy(this.opts.dir, this.originalResourcesAppDir, {
       filter: ignore.userIgnoreFilter(this.opts),
       dereference: this.opts.derefSymlinks
-    }).then(() => common.promisifyHooks(this.opts.afterCopy, [
+    }).then(() => hooks.promisifyHooks(this.opts.afterCopy, [
       this.originalResourcesAppDir,
       this.opts.electronVersion,
       this.opts.platform,
@@ -132,7 +133,7 @@ class App {
   prune () {
     if (this.opts.prune || this.opts.prune === undefined) {
       return pruneModules(this.opts, this.originalResourcesAppDir)
-        .then(() => common.promisifyHooks(this.opts.afterPrune, [this.originalResourcesAppDir, this.opts.electronVersion, this.opts.platform, this.opts.arch]))
+        .then(() => hooks.promisifyHooks(this.opts.afterPrune, [this.originalResourcesAppDir, this.opts.electronVersion, this.opts.platform, this.opts.arch]))
     }
 
     return Promise.resolve()

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const config = require('./config.json')
+const hooks = require('../hooks')
 const packager = require('..')
+const test = require('ava')
 const util = require('./_util')
 
 function createHookTest (hookName) {
@@ -32,3 +34,49 @@ function createHookTest (hookName) {
 createHookTest('afterCopy')
 createHookTest('afterPrune')
 createHookTest('afterExtract')
+
+test('promisifyHooks executes functions in parallel', t => {
+  let output = '0'
+  const testHooks = [
+    done => { output += ' 1'; done() },
+    done => { setTimeout(() => { output += ' 2'; done() }, 1000) },
+    done => { output += ' 3'; done() },
+    done => { setTimeout(() => { output += ' 4'; done() }, 1000) },
+    done => { output += ' 5'; done() },
+    done => { setTimeout(() => { output += ' 6'; done() }, 1000) },
+    done => { output += ' 7'; done() },
+    done => { setTimeout(() => { output += ' 8'; done() }, 1000) },
+    done => { output += ' 9'; done() },
+    done => { setTimeout(() => { output += ' 10'; done() }, 1000) }
+  ]
+
+  return hooks.promisifyHooks(testHooks)
+    .then(() => t.not(output, '0 1 2 3 4 5 6 7 8 9 10', 'should not be in sequential order'))
+})
+
+test('serialHooks executes functions serially', t => {
+  let output = '0'
+  const timeoutFunc = number => {
+    return () => new Promise(resolve => { // eslint-disable-line promise/avoid-new
+      setTimeout(() => {
+        output += ` ${number}`
+        resolve()
+      }, 1000)
+    })
+  }
+  const testHooks = [
+    () => { output += ' 1'; return Promise.resolve() },
+    timeoutFunc(2),
+    () => { output += ' 3'; return Promise.resolve() },
+    timeoutFunc(4),
+    () => { output += ' 5'; return Promise.resolve() },
+    timeoutFunc(6),
+    () => { output += ' 7'; return Promise.resolve() },
+    timeoutFunc(8),
+    () => { output += ' 9'; return Promise.resolve() },
+    timeoutFunc(10)
+  ]
+
+  return hooks.serialHooks(testHooks)(() => output)
+    .then(result => t.is(result, '0 1 2 3 4 5 6 7 8 9 10', 'should be in sequential order'))
+})


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Adds `serialHooks(hooks)` (ported from Electron Forge), which allows a user to run hooks serially instead of in parallel (which was added in v10.0.0 due to `Promise.all`).

Closes #812.