### PR TITLE
#831 Update node version check to support node 10

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,8 +2,8 @@
 
 'use strict'
 
-var nodeVersionInfo = process.versions.node.split('.').map(function (n) { return Number(n) })
-if (nodeVersionInfo < [4, 0, 0]) {
+var nodeMajorVersion = Number(process.versions.node.split('.')[0])
+if (nodeMajorVersion < 4) {
   console.error('CANNOT RUN WITH NODE ' + process.versions.node)
   console.error('Electron Packager requires Node 4.0 or above.')
   process.exit(1)


### PR DESCRIPTION
Update the node version check to support node 10 (#831). The current check fails once the node version hits double figures.

This PR simplifies the check to only compare the major version number.