### PR TITLE
Deprecate the callback version of the packager API

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -38,13 +38,13 @@ if (args.help) {
   printUsageAndExit(true)
 }
 
-packager(args, function done (err, appPaths) {
-  if (err) {
+packager(args)
+  .then(function done (appPaths) {
+    if (appPaths.length > 1) console.error('Wrote new apps to:\n' + appPaths.join('\n'))
+    else if (appPaths.length === 1) console.error('Wrote new app to', appPaths[0])
+    return true
+  }).catch(function error (err) {
     if (err.message) console.error(err.message)
     else console.error(err, err.stack)
     process.exit(1)
-  }
-
-  if (appPaths.length > 1) console.error('Wrote new apps to:\n' + appPaths.join('\n'))
-  else if (appPaths.length === 1) console.error('Wrote new app to', appPaths[0])
-})
+  })

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,18 +1,18 @@
 # electron-packager API
 
-Short [callback](#callback) example:
-
-```javascript
-const packager = require('electron-packager')
-packager(options, function done_callback (err, appPaths) { /* … */ })
-```
-
 Short Promise example:
 
 ```javascript
 const packager = require('electron-packager')
 packager(options)
-  .then((appPaths) => { /* … */ })
+  .then(appPaths => { /* … */ })
+```
+
+Short [(deprecated) callback syntax](#callback) example:
+
+```javascript
+const packager = require('electron-packager')
+packager(options, function done_callback (err, appPaths) { /* … */ })
 ```
 
 ## `options`

--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ function packagerPromise (opts) {
 
 module.exports = function packager (opts, cb) {
   if (cb) {
+    /* istanbul ignore next */
     common.warning('The callback-based version of packager() is deprecated and will be removed in a future major version, please convert to the Promise version or use the nodeify module.')
   }
   return nodeify(packagerPromise(opts), cb)

--- a/index.js
+++ b/index.js
@@ -180,5 +180,8 @@ function packagerPromise (opts) {
 }
 
 module.exports = function packager (opts, cb) {
+  if (cb) {
+    common.warning('The callback-based version of packager() is deprecated and will be removed in a future major version, please convert to the Promise version or use the nodeify module.')
+  }
   return nodeify(packagerPromise(opts), cb)
 }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Just so everyone's clear: when callback-style syntax is removed from Electron Packager, folks will have to add [`nodeify`](https://npm.im/nodeify) to their dependencies if they want to keep using that syntax.