### PR TITLE
Add --version to print out Packager/Node versions, target platform/arch

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,12 @@ function printUsageAndExit (isError) {
 
 if (args.help) {
   printUsageAndExit(false)
+} else if (args.version) {
+  if (typeof args.version !== 'boolean') {
+    console.error('--version does not take an argument. Perhaps you meant --app-version or --electron-version?\n')
+  }
+  console.log(common.hostInfo())
+  process.exit(0)
 } else if (!args.dir) {
   printUsageAndExit(true)
 }

--- a/common.js
+++ b/common.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const metadata = require('./package.json')
 const os = require('os')
 const path = require('path')
 const sanitize = require('sanitize-filename')
@@ -149,6 +150,11 @@ module.exports = {
     return pathToNormalize.replace(/\\/g, '/')
   },
 
+  hostInfo: function hostInfo () {
+    return `Electron Packager ${metadata.version}\n` +
+      `Node ${process.version}\n` +
+      `Host Operating system: ${process.platform} (${process.arch})`
+  },
   info: info,
   warning: warning
 }

--- a/index.js
+++ b/index.js
@@ -8,16 +8,13 @@ const fs = require('fs-extra')
 const getMetadataFromPackageJSON = require('./infer')
 const hooks = require('./hooks')
 const ignore = require('./ignore')
-const metadata = require('./package.json')
 const nodeify = require('nodeify')
 const path = require('path')
 const pify = require('pify')
 const targets = require('./targets')
 
 function debugHostInfo () {
-  debug(`Electron Packager ${metadata.version}`)
-  debug(`Node ${process.version}`)
-  debug(`Host Operating system: ${process.platform} (${process.arch})`)
+  debug(common.hostInfo())
 }
 
 class Packager {

--- a/usage.txt
+++ b/usage.txt
@@ -1,16 +1,21 @@
 Usage: electron-packager <sourcedir> <appname> [options...]
 
-Required options
+Required parameters
 
 sourcedir          the base directory of the application source
 
   Examples:        electron-packager ./
                    electron-packager ./ --all
 
-Optional options
+Optional parameters
 
 appname            the name of the app, if it needs to be different from the "productName" or "name"
                    in the nearest package.json
+
+Options
+
+version            prints the version of Electron Packager and Node, plus the target platform and
+                   arch, for bug reporting purposes, and exits immediately
 
 * All platforms *
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Re-add `--version`, but this time make it have the behavior that most other CLIs have. If it is given a value, it will print a warning about possible other related flags.