### PR TITLE
Prevent trying to download mips64el arch for Electron 2.x

### DIFF
--- a/targets.js
+++ b/targets.js
@@ -13,9 +13,9 @@ const officialPlatformArchCombos = {
   win32: ['ia32', 'x64']
 }
 
-const minimumLinuxArchBuildVersions = {
-  arm64: '1.8.0',
-  mips64el: '1.8.2-beta.5'
+const linuxArchBuildVersions = {
+  arm64: '>= 1.8.0',
+  mips64el: '^1.8.2-beta.5'
 }
 
 // Maps to module filename for each platform (lazy-required if used)
@@ -40,9 +40,9 @@ function createPlatformArchPairs (opts, selectedPlatforms, selectedArchs, ignore
           warnIfAllNotSpecified(opts, `The platform/arch combination ${platform}/${arch} is not currently supported by Electron Packager`)
           continue
         } else if (platform === 'linux') {
-          const minimumBuildVersion = minimumLinuxArchBuildVersions[arch]
-          if (minimumBuildVersion && !officialLinuxBuildExists(opts, minimumBuildVersion)) {
-            warnIfAllNotSpecified(opts, `Official linux/${arch} support only exists in Electron ${minimumBuildVersion} and above`)
+          const buildVersion = linuxArchBuildVersions[arch]
+          if (buildVersion && !officialLinuxBuildExists(opts, buildVersion)) {
+            warnIfAllNotSpecified(opts, `Official linux/${arch} support only exists in Electron ${buildVersion}`)
             continue
           }
         }
@@ -67,8 +67,8 @@ function validOfficialPlatformArch (opts, platform, arch) {
   return officialPlatformArchCombos[platform] && officialPlatformArchCombos[platform].indexOf(arch) !== -1
 }
 
-function officialLinuxBuildExists (opts, minimumBuildVersion) {
-  return semver.gte(opts.electronVersion, minimumBuildVersion)
+function officialLinuxBuildExists (opts, buildVersion) {
+  return semver.satisfies(opts.electronVersion, buildVersion)
 }
 
 function allPlatformsOrArchsSpecified (opts) {
@@ -100,8 +100,8 @@ module.exports = {
   allOfficialArchsForPlatformAndVersion: function allOfficialArchsForPlatformAndVersion (platform, electronVersion) {
     const archs = officialPlatformArchCombos[platform]
     if (platform === 'linux') {
-      const excludedArchs = Object.keys(minimumLinuxArchBuildVersions)
-        .filter(arch => !officialLinuxBuildExists({electronVersion: electronVersion}, minimumLinuxArchBuildVersions[arch]))
+      const excludedArchs = Object.keys(linuxArchBuildVersions)
+        .filter(arch => !officialLinuxBuildExists({electronVersion: electronVersion}, linuxArchBuildVersions[arch]))
       return archs.filter(arch => excludedArchs.indexOf(arch) === -1)
     }
 

--- a/test/targets.js
+++ b/test/targets.js
@@ -126,6 +126,7 @@ testMultiTarget('platform=linux and arch=arm64 with a supported official Electro
 testMultiTarget('platform=linux and arch=arm64 with an unsupported official Electron version', {arch: 'arm64', platform: 'linux'}, 0, 'Package should not be generated for arm64')
 testMultiTarget('platform=linux and arch=mips64el with a supported official Electron version', {arch: 'mips64el', platform: 'linux', electronVersion: '1.8.2-beta.5'}, 1, 'Package should be generated for mips64el')
 testMultiTarget('platform=linux and arch=mips64el with an unsupported official Electron version', {arch: 'mips64el', platform: 'linux'}, 0, 'Package should not be generated for mips64el')
+testMultiTarget('platform=linux and arch=mips64el with an unsupported official Electron version (2.0.0)', {arch: 'mips64el', platform: 'linux', electronVersion: '2.0.0'}, 0, 'Package should not be generated for mips64el')
 testMultiTarget('unofficial arch', {arch: 'z80', platform: 'linux', download: {mirror: 'mirror'}}, 1,
                 'Package should be generated for non-standard arch from non-official mirror')
 testMultiTarget('unofficial platform', {arch: 'ia32', platform: 'minix', download: {mirror: 'mirror'}}, 1,


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This fixes `all: true` and `platform:linux` + `arch: all` cases as well.

See also: https://github.com/electron/electronjs.org/pull/1252