### PR TITLE
feat: add darwinDarkModeSupport option to support mojave dark mode for older Electron versions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -232,7 +232,7 @@ valid versions. If omitted, it will use the version of the nearest local install
 
 ##### `darwinDarkModeSupport`
 
-*Boolean*
+*Boolean* (default: `false`)
 
 Forces support for Mojave (macOS 10.14) dark mode in your packaged app, this sets the
 `NSRequiresAquaSystemAppearance` key to `false` in your app's `Info.plist`.  For more

--- a/docs/api.md
+++ b/docs/api.md
@@ -230,6 +230,14 @@ valid versions. If omitted, it will use the version of the nearest local install
 `electron`, `electron-prebuilt-compile`, or `electron-prebuilt`, defined in `package.json` in either
 `dependencies` or `devDependencies`.
 
+##### `darwinDarkModeSupport`
+
+*Boolean*
+
+Forces support for Mojave (macOS 10.14) dark mode in your packaged app, this sets the
+`NSRequiresAquaSystemAppearance` key to `false` in your app's `Info.plist`.  For more
+information see the [Apple developer documentation](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app).
+
 ##### `extraResource`
 
 *String* or *Array* of *String*s

--- a/mac.js
+++ b/mac.js
@@ -31,6 +31,10 @@ class MacApp extends App {
     return this.opts.buildVersion
   }
 
+  get enableDarkMode () {
+    return this.opts.darwinDarkModeSupport
+  }
+
   get protocols () {
     return this.opts.protocols.map((protocol) => {
       return {
@@ -210,6 +214,10 @@ class MacApp extends App {
 
         if (this.appCopyright) {
           this.appPlist.NSHumanReadableCopyright = this.appCopyright
+        }
+
+        if (this.enableDarkMode) {
+          this.appPlist.NSRequiresAquaSystemAppearance = false
         }
 
         return Promise.all(plists.map(plistArgs => {

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -128,6 +128,20 @@ function extendInfoTest (t, baseOpts, extraPathOrParams) {
     })
 }
 
+function darkModeTest (t, baseOpts) {
+  const opts = Object.assign({}, baseOpts, {
+    appBundleId: 'com.electron.extratest',
+    appCategoryType: 'public.app-category.music',
+    buildVersion: '3.2.1',
+    darwinDarkModeSupport: true
+  })
+
+  return packageAndParseInfoPlist(t, opts)
+    .then(obj => {
+      return t.is(obj.NSRequiresAquaSystemAppearance, false, 'NSRequiresAquaSystemAppearance should be set to false')
+    })
+}
+
 function binaryNameTest (t, baseOpts, extraOpts, expectedExecutableName, expectedAppName) {
   const opts = Object.assign({}, baseOpts, extraOpts)
   const appName = expectedAppName || expectedExecutableName || opts.name
@@ -258,6 +272,7 @@ if (!(process.env.CI && process.platform === 'win32')) {
 
   darwinTest('extendInfo by filename test', extendInfoTest, extraInfoPath)
   darwinTest('extendInfo by params test', extendInfoTest, extraInfoParams)
+  darwinTest('mojave dark mode test: should enable dark mode', darkModeTest)
 
   darwinTest('protocol/protocol-name argument test', (t, opts) => {
     opts.protocols = [

--- a/usage.txt
+++ b/usage.txt
@@ -69,6 +69,8 @@ app-bundle-id      bundle identifier to use in the app plist
 app-category-type  the application category type
                    For example, `app-category-type=public.app-category.developer-tools` will set the
                    application category to 'Developer Tools'.
+darwin-dark-mode-support
+                   forces support for Mojave/10.14 dark mode in the packaged app
 extend-info        a plist file to merge into the app plist
 helper-bundle-id   bundle identifier to use in the app helper plist
 osx-sign           (OSX host platform only) Whether to sign the OSX app packages. You can either


### PR DESCRIPTION
Refs: https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app