### PR TITLE
Drop callback support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,12 @@
 # electron-packager API
 
+Short `async`/`await` example:
+
+```javascript
+const packager = require('electron-packager')
+const appPaths = await packager(options)
+```
+
 Short Promise example:
 
 ```javascript
@@ -8,12 +15,7 @@ packager(options)
   .then(appPaths => { /* … */ })
 ```
 
-Short [(deprecated) callback syntax](#callback) example:
-
-```javascript
-const packager = require('electron-packager')
-packager(options, function done_callback (err, appPaths) { /* … */ })
-```
+`appPaths` is described in the [return value](#return-value) section.
 
 ## `options`
 
@@ -461,13 +463,7 @@ Object (also known as a "hash") of application metadata to embed into the execut
 
 For more information, see the [`node-rcedit` module](https://github.com/electron/node-rcedit).
 
-## callback
-
-### `err`
-
-*Error* (or *Array*, in the case of an `copy` error)
-
-Contains errors, if any.
+## Return value
 
 ### `appPaths`
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const fs = require('fs-extra')
 const getMetadataFromPackageJSON = require('./infer')
 const hooks = require('./hooks')
 const ignore = require('./ignore')
-const nodeify = require('nodeify')
 const path = require('path')
 const pify = require('pify')
 const targets = require('./targets')
@@ -145,7 +144,7 @@ function packageAllSpecifiedCombos (opts, archs, platforms) {
     )))
 }
 
-function packagerPromise (opts) {
+module.exports = function packager (opts) {
   debugHostInfo()
   if (debug.enabled) debug(`Packager Options: ${JSON.stringify(opts)}`)
 
@@ -174,12 +173,4 @@ function packagerPromise (opts) {
     })
     // Remove falsy entries (e.g. skipped platforms)
     .then(appPaths => appPaths.filter(appPath => appPath))
-}
-
-module.exports = function packager (opts, cb) {
-  if (cb) {
-    /* istanbul ignore next */
-    common.warning('The callback-based version of packager() is deprecated and will be removed in a future major version, please convert to the Promise version or use the nodeify module.')
-  }
-  return nodeify(packagerPromise(opts), cb)
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "fs-extra": "^7.0.0",
     "galactus": "^0.2.1",
     "get-package-info": "^1.0.0",
-    "nodeify": "^1.0.1",
     "parse-author": "^2.0.0",
     "pify": "^4.0.0",
     "plist": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -61,10 +61,10 @@ It generates executables/bundles for the following **target** platforms:
 This module requires Node.js 6.0 or higher to run.
 
 ```sh
-# for use in npm scripts
+# For use in npm scripts (recommended)
 npm install electron-packager --save-dev
 
-# for use from cli
+# For use from the CLI
 npm install electron-packager -g
 ```
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Removes callback-style support (use `nodeify` if you need that still), and adds an `async`/`await` example to the API docs.