### PR TITLE
Use Travis CI for some Windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-sudo: required
 os:
 - linux
 - osx
-dist: trusty
-osx_image: xcode8
+- windows
+dist: xenial
+osx_image: xcode9.4
 language: node_js
 node_js:
 - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
 - osx
 - windows
 dist: xenial
-osx_image: xcode9.4
+osx_image: xcode8
 language: node_js
 node_js:
 - '6'

--- a/test/ci/appveyor.yml
+++ b/test/ci/appveyor.yml
@@ -1,6 +1,5 @@
 platform:
 - x86
-- x64
 environment:
   matrix:
   - nodejs_version: "6"

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -3,9 +3,6 @@
 
 case "$TRAVIS_OS_NAME" in
   "linux")
-    # Not using Trusty containers because it can't install wine1.6(-i386),
-    # see: https://github.com/travis-ci/travis-ci/issues/6460
-    sudo rm /etc/apt/sources.list.d/google-chrome.list
     sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install -y wine1.6


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

Use Travis CI's (currently in beta) Windows support for x64 tests. Keep the x86 tests on AppVeyor.

Also update Linux CI to use Ubuntu 16.04.