### PR TITLE
Ensure relative out dirs are correctly ignored when copying

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -69,11 +69,12 @@ function userIgnoreFilter (opts) {
   const pruner = opts.prune ? new prune.Pruner(opts.dir) : null
 
   return function filter (file) {
-    if (outIgnores.includes(file)) {
+    const fullPath = path.resolve(file)
+    if (outIgnores.includes(fullPath)) {
       return false
     }
 
-    let name = path.resolve(file).split(path.resolve(opts.dir))[1]
+    let name = fullPath.split(path.resolve(opts.dir))[1]
 
     if (path.sep === '\\') {
       name = common.normalizePath(name)

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -4,7 +4,6 @@ const common = require('../common')
 const fs = require('fs-extra')
 const ignore = require('../ignore')
 const path = require('path')
-const packager = require('..')
 const test = require('ava')
 const util = require('./_util')
 
@@ -24,15 +23,16 @@ function ignoreTest (t, opts, ignorePattern, ignoredFile) {
     .then(() => util.assertPathNotExists(t, path.join(targetDir, ignoredFile), `Ignored file '${ignoredFile}' should not exist in copied directory`))
 }
 
-function assertOutDirIgnored (t, opts, pathPrefix, existingDirectoryPath, pathToIgnore, ignoredBasenameToCheck) {
+function assertOutDirIgnored (t, opts, existingDirectoryPath, pathToIgnore, ignoredBasenameToCheck) {
   return fs.copy(util.fixtureSubdir('basic'), t.context.workDir, {
     dereference: true,
     stopOnErr: true,
     filter: file => path.basename(file) !== 'node_modules'
   }).then(() => fs.ensureDir(existingDirectoryPath))
     // create file to ensure that directory will be not ignored because it's empty
-    .then(() => fs.writeFile(pathToIgnore, '')).then(() => packager(opts))
-    .then(() => util.assertPathNotExists(t, path.join(pathPrefix, common.generateFinalBasename(opts), util.generateResourcesPath(opts), 'app', ignoredBasenameToCheck), 'Out dir must not exist in output app directory'))
+    .then(() => fs.writeFile(pathToIgnore, ''))
+    .then(() => util.packageAndEnsureResourcesPath(t, opts))
+    .then(resourcesPath => util.assertPathNotExists(t, path.join(resourcesPath, 'app', ignoredBasenameToCheck), 'Out dir must not exist in output app directory'))
 }
 
 function ignoreOutDirTest (t, opts, distPath) {
@@ -43,7 +43,7 @@ function ignoreOutDirTest (t, opts, distPath) {
   // we don't use path.join here to avoid normalizing
   opts.out = opts.dir + path.sep + distPath
 
-  return assertOutDirIgnored(t, opts, opts.out, opts.out, path.join(opts.out, 'ignoreMe'), path.basename(opts.out))
+  return assertOutDirIgnored(t, opts, opts.out, path.join(opts.out, 'ignoreMe'), path.basename(opts.out))
 }
 
 function ignoreImplicitOutDirTest (t, opts) {
@@ -54,7 +54,7 @@ function ignoreImplicitOutDirTest (t, opts) {
   const testFilename = 'ignoreMe'
   const previousPackedResultDir = path.join(opts.dir, `${common.sanitizeAppName(opts.name)}-linux-ia32`)
 
-  return assertOutDirIgnored(t, opts, opts.dir, previousPackedResultDir, path.join(previousPackedResultDir, testFilename), testFilename)
+  return assertOutDirIgnored(t, opts, previousPackedResultDir, path.join(previousPackedResultDir, testFilename), testFilename)
 }
 
 test('generateIgnores ignores the generated temporary directory only on Linux', t => {
@@ -92,3 +92,19 @@ util.testSinglePlatform('ignore out dir test', ignoreOutDirTest, 'ignoredOutDir'
 util.testSinglePlatform('ignore out dir test: unnormalized path', ignoreOutDirTest,
                         './ignoredOutDir')
 util.testSinglePlatform('ignore out dir test: implicit path', ignoreImplicitOutDirTest)
+util.testSinglePlatform('ignore out dir test: relative out dir already exists', (t, opts) => {
+  const appDir = path.join(t.context.tempDir, 'app')
+
+  opts.name = 'ignoredOutDirTest'
+  opts.dir = '.'
+  opts.out = 'dir_to_unpack' // already existing out dir
+
+  return fs.copy(util.fixtureSubdir('basic'), appDir)
+    .then(() => {
+      process.chdir(appDir)
+      return util.packageAndEnsureResourcesPath(t, opts)
+    }).then(resourcesPath => {
+      const packagedOutDirPath = path.join(resourcesPath, 'app', opts.out)
+      return util.assertPathNotExists(t, packagedOutDirPath, `The out dir ${packagedOutDirPath} should not exist in the packaged app`)
+    })
+})

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -93,11 +93,12 @@ util.testSinglePlatform('ignore out dir test: unnormalized path', ignoreOutDirTe
                         './ignoredOutDir')
 util.testSinglePlatform('ignore out dir test: implicit path', ignoreImplicitOutDirTest)
 util.testSinglePlatform('ignore out dir test: relative out dir already exists', (t, opts) => {
-  const appDir = path.join(t.context.tempDir, 'app')
+  const appDir = path.join(t.context.workDir, 'app')
 
   opts.name = 'ignoredOutDirTest'
   opts.dir = '.'
   opts.out = 'dir_to_unpack' // already existing out dir
+  opts.overwrite = true
 
   return fs.copy(util.fixtureSubdir('basic'), appDir)
     .then(() => {

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -105,6 +105,7 @@ util.testSinglePlatform('ignore out dir test: relative out dir already exists', 
       process.chdir(appDir)
       return util.packageAndEnsureResourcesPath(t, opts)
     }).then(resourcesPath => {
+      process.chdir(t.context.workdir)
       const packagedOutDirPath = path.join(resourcesPath, 'app', opts.out)
       return util.assertPathNotExists(t, packagedOutDirPath, `The out dir ${packagedOutDirPath} should not exist in the packaged app`)
     })

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -93,6 +93,7 @@ util.testSinglePlatform('ignore out dir test: unnormalized path', ignoreOutDirTe
                         './ignoredOutDir')
 util.testSinglePlatform('ignore out dir test: implicit path', ignoreImplicitOutDirTest)
 util.testSinglePlatform('ignore out dir test: relative out dir already exists', (t, opts) => {
+  const oldCWD = process.cwd()
   const appDir = path.join(t.context.workDir, 'app')
 
   opts.name = 'ignoredOutDirTest'
@@ -105,7 +106,7 @@ util.testSinglePlatform('ignore out dir test: relative out dir already exists', 
       process.chdir(appDir)
       return util.packageAndEnsureResourcesPath(t, opts)
     }).then(resourcesPath => {
-      process.chdir(t.context.workdir)
+      process.chdir(oldCWD)
       const packagedOutDirPath = path.join(resourcesPath, 'app', opts.out)
       return util.assertPathNotExists(t, packagedOutDirPath, `The out dir ${packagedOutDirPath} should not exist in the packaged app`)
     })


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This happens when both the dir and the out dir are relative to the current working directory.

Fixes #918.