### PR TITLE
Add support for inferring version from Electron nightlies

### DIFF
--- a/infer.js
+++ b/infer.js
@@ -97,6 +97,8 @@ module.exports = function getMetadataFromPackageJSON (platforms, opts, dir) {
     props.push([
       'dependencies.electron',
       'devDependencies.electron',
+      'dependencies.electron-nightly',
+      'devDependencies.electron-nightly',
       'dependencies.electron-prebuilt-compile',
       'devDependencies.electron-prebuilt-compile',
       'dependencies.electron-prebuilt',

--- a/test/fixtures/infer-electron-nightly/node_modules/electron-nightly/package.json
+++ b/test/fixtures/infer-electron-nightly/node_modules/electron-nightly/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "electron-nightly",
+  "version": "5.0.0-nightly.20190107",
+  "main": "index.js"
+}

--- a/test/fixtures/infer-electron-nightly/package.json
+++ b/test/fixtures/infer-electron-nightly/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "main.js",
+  "productName": "MainJS",
+  "devDependencies": {
+    "electron-nightly": "5.0.0-nightly.20190107"
+  }
+}

--- a/test/infer.js
+++ b/test/infer.js
@@ -84,6 +84,7 @@ function testInferWin32metadataAuthorObject (t, opts, author, expected, assertio
 }
 
 util.testSinglePlatformParallel('infer using `electron-prebuilt` package', inferElectronVersionTest, 'basic', 'electron-prebuilt')
+util.testSinglePlatformParallel('infer using `electron-nightly` package', inferElectronVersionTest, 'infer-electron-nightly', 'electron-nightly')
 util.testSinglePlatformParallel('infer using `electron-prebuilt-compile` package', inferElectronVersionTest, 'infer-electron-prebuilt-compile', 'electron-prebuilt-compile')
 util.testSinglePlatformParallel('infer using `electron` package only', inferMissingVersionTest)
 util.testSinglePlatformParallel('infer where `electron` version is preferred over `electron-prebuilt`', inferElectronVersionTest, 'basic-renamed-to-electron', 'electron')


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Nightlies were [moved to `electron-nightly`](https://github.com/electron/electron/pull/15938).