### PR TITLE
fix(targets): Linux/ia32 is no longer supported for Electron >= 4

### DIFF
--- a/targets.js
+++ b/targets.js
@@ -15,6 +15,7 @@ const officialPlatformArchCombos = {
 
 const linuxArchBuildVersions = {
   arm64: '>= 1.8.0',
+  ia32: '< 4.0.0-beta.1',
   mips64el: '^1.8.2-beta.5'
 }
 

--- a/test/targets.js
+++ b/test/targets.js
@@ -52,6 +52,13 @@ test('allOfficialArchsForPlatformAndVersion returns mips64el when the correct ve
           'should not be found when version is < 1.8.2-beta.5')
 })
 
+test('allOfficialArchsForPlatformAndVersion returns ia32 when the correct version is specified', t => {
+  t.true(targets.allOfficialArchsForPlatformAndVersion('linux', '2.0.0').includes('ia32'),
+         'should be found when version is < 4.0.0')
+  t.false(targets.allOfficialArchsForPlatformAndVersion('linux', '4.0.0').includes('ia32'),
+          'should not be found when version is >= 4.0.0-beta.1')
+})
+
 test('validateListFromOptions does not take non-Array/String values', t => {
   targets.supported.digits = new Set(['64', '65'])
   t.false(targets.validateListFromOptions({ digits: 64 }, 'digits') instanceof Array,


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

See:

* https://electronjs.org/blog/linux-32bit-support
* https://github.com/electron/electron/issues/16407