### PR TITLE
Drop mz for util.promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "mz": "^2.6.0",
     "nyc": "^14.0.0",
     "pkg-up": "^3.0.1",
     "sinon": "^7.0.0",

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -3,11 +3,14 @@
 const common = require('../src/common')
 const download = require('../src/download')
 const config = require('./config.json')
-const { exec } = require('mz/child_process')
+const childProcess = require('child_process')
 const fs = require('fs-extra')
 const os = require('os')
 const path = require('path')
+const { promisify } = require('util')
 const targets = require('../src/targets')
+
+childProcess.exec = promisify(childProcess.exec)
 
 function fixtureSubdir (subdir) {
   return path.join(__dirname, 'fixtures', subdir)
@@ -66,7 +69,7 @@ async function npmInstallForFixture (fixture) {
     return true
   } else {
     console.log(`Running npm install in fixtures/${fixture}...`)
-    return exec('npm install --no-bin-links', { cwd: fixtureDir })
+    return childProcess.exec('npm install --no-bin-links', { cwd: fixtureDir })
   }
 }
 

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -1,14 +1,17 @@
 'use strict'
 
 const config = require('./config.json')
-const { exec } = require('mz/child_process')
+const childProcess = require('child_process')
 const fs = require('fs-extra')
 const mac = require('../src/mac')
 const packager = require('..')
 const path = require('path')
 const plist = require('plist')
+const { promisify } = require('util')
 const test = require('ava')
 const util = require('./_util')
+
+childProcess.exec = promisify(childProcess.exec)
 
 const darwinOpts = {
   name: 'darwinTest',
@@ -296,7 +299,7 @@ if (!(process.env.CI && process.platform === 'win32')) {
     const appPath = path.join(finalPath, opts.name + '.app')
     await util.assertDirectory(t, appPath, 'The expected .app directory should exist')
     try {
-      await exec(`codesign -v ${appPath}`)
+      await childProcess.exec(`codesign -v ${appPath}`)
       t.pass('codesign should verify successfully')
     } catch (err) {
       const notFound = err && err.code === 127


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

With the Node 8 changes, `mz` is no longer necessary. One less dependency!