### PR TITLE
Replace extract-zip with cross-zip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ feature. Known modules include:
 * `electron-download`
 * `electron-osx-sign`
 * `electron-packager` (always use this one before filing an issue)
-* `extract-zip`
 * `get-package-info`
 
 We use the [`debug`](https://www.npmjs.com/package/debug#usage) module for this functionality. It

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
     "asar": "^2.0.1",
+    "cross-zip": "^2.1.5",
     "debug": "^4.0.1",
     "electron-download": "^4.1.1",
     "electron-notarize": "^0.1.0",
     "electron-osx-sign": "^0.4.11",
-    "extract-zip": "^1.0.3",
     "fs-extra": "^7.0.0",
     "galactus": "^0.2.1",
     "get-package-info": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 const common = require('./common')
 const debug = require('debug')('electron-packager')
 const download = require('./download')
-const extract = require('extract-zip')
 const fs = require('fs-extra')
 const getMetadataFromPackageJSON = require('./infer')
 const hooks = require('./hooks')
@@ -11,6 +10,9 @@ const ignore = require('./ignore')
 const path = require('path')
 const { promisify } = require('util')
 const targets = require('./targets')
+const zip = require('cross-zip')
+
+const unzip = promisify(zip.unzip)
 
 function debugHostInfo () {
   debug(common.hostInfo())
@@ -68,7 +70,7 @@ class Packager {
 
   async extractElectronZip (comboOpts, zipPath, buildDir) {
     debug(`Extracting ${zipPath} to ${buildDir}`)
-    await promisify(extract)(zipPath, { dir: buildDir })
+    await unzip(zipPath, buildDir)
     await hooks.promisifyHooks(this.opts.afterExtract, [buildDir, comboOpts.electronVersion, comboOpts.platform, comboOpts.arch])
   }
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`extract-zip` is effectively unmaintained, and we're already using `cross-zip` in Forge (for different reasons).

`cross-zip` also has fewer Node dependencies, although the tradeoff is that [on Windows it requires a certain version of .NET Framework & Powershell](https://github.com/feross/cross-zip/blob/v2.1.5/README.md#windows-users).