### PR TITLE
 feat: convert from electron-download to @electron/get 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ calling electron-packager. This will print debug information from the specified 
 value of the environment variable is a comma-separated list of modules which support this logging
 feature. Known modules include:
 
-* `electron-download`
+* `@electron/get:*`
 * `electron-osx-sign`
 * `electron-packager` (always use this one before filing an issue)
 * `get-package-info`

--- a/docs/api.md
+++ b/docs/api.md
@@ -182,7 +182,7 @@ Not required if the [`all`](#all) option is set.
 If `arch` is set to `all`, all supported architectures for the target platforms specified by [`platform`](#platform) will be built.
 Arbitrary combinations of individual architectures are also supported via a comma-delimited string or array of strings.
 The non-`all` values correspond to the architecture names used by [Electron releases]. This value
-is not restricted to the official set if [`download.mirror`](#download) is set.
+is not restricted to the official set if [`download.mirrorOptions`](#download) is set.
 
 ##### `asar`
 
@@ -220,14 +220,13 @@ Whether symlinks should be dereferenced during the copying of the application so
 
 *Object*
 
-If present, passes custom options to [`electron-download`](https://www.npmjs.com/package/electron-download)
+If present, passes custom options to [`@electron/get`](https://npm.im/@electron/get)
 (see the link for more detailed option descriptions and the defaults). Supported parameters include,
 but are not limited to:
-- `cache` (*String*): The directory where prebuilt, pre-packaged Electron downloads are cached.
-- `mirror` (*String*): The URL to override the default Electron download location.
-- `quiet` (*Boolean* - default: `false`): Whether to show a progress bar when downloading Electron.
-- `strictSSL` (*Boolean* - default: `true`): Whether SSL certificates are required to be valid when
-  downloading Electron.
+- `cacheRoot` (*String*): The directory where prebuilt, pre-packaged Electron downloads are cached.
+- `mirrorOptions` (*Object*): Options to override the default Electron download location.
+- `rejectUnauthorized` (*Boolean* - default: `true`): Whether SSL certificates are required to be
+  valid when downloading Electron.
 
 
 ##### `electronVersion`
@@ -352,7 +351,7 @@ Not required if the [`all`](#all) option is set.
 If `platform` is set to `all`, all [supported target platforms](#supported-platforms) for the target architectures specified by [`arch`](#arch) will be built.
 Arbitrary combinations of individual platforms are also supported via a comma-delimited string or array of strings.
 The non-`all` values correspond to the platform names used by [Electron releases]. This value
-is not restricted to the official set if [`download.mirror`](#download) is set.
+is not restricted to the official set if [`download.mirrorOptions`](#download) is set.
 
 ##### `prebuiltAsar`
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
+    "@electron/get": "^1.1.1",
     "asar": "^2.0.1",
     "cross-zip": "^2.1.5",
     "debug": "^4.0.1",
-    "electron-download": "^4.1.1",
     "electron-notarize": "^0.1.1",
     "electron-osx-sign": "^0.4.11",
     "fs-extra": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/electron-userland/electron-packager",
   "dependencies": {
-    "@electron/get": "^1.1.1",
+    "@electron/get": "^1.2.0",
     "asar": "^2.0.1",
     "cross-zip": "^2.1.5",
     "debug": "^4.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,7 +20,7 @@ module.exports = {
       boolean: [
         'all',
         'deref-symlinks',
-        'download.strictSSL',
+        'download.rejectUnauthorized',
         'junk',
         'overwrite',
         'prune',
@@ -28,7 +28,7 @@ module.exports = {
       ],
       default: {
         'deref-symlinks': true,
-        'download.strictSSL': true,
+        'download.rejectUnauthorized': true,
         junk: true,
         prune: true
       },

--- a/src/download.js
+++ b/src/download.js
@@ -2,8 +2,7 @@
 
 const common = require('./common')
 const debug = require('debug')('electron-packager')
-const download = require('electron-download')
-const { promisify } = require('util')
+const { downloadArtifact } = require('@electron/get')
 const semver = require('semver')
 const targets = require('./targets')
 
@@ -13,6 +12,7 @@ function createDownloadOpts (opts, platform, arch) {
   common.subOptionWarning(downloadOpts, 'download', 'platform', platform, opts.quiet)
   common.subOptionWarning(downloadOpts, 'download', 'arch', arch, opts.quiet)
   common.subOptionWarning(downloadOpts, 'download', 'version', opts.electronVersion, opts.quiet)
+  common.subOptionWarning(downloadOpts, 'download', 'artifactName', 'electron', opts.quiet)
 
   return downloadOpts
 }
@@ -32,6 +32,6 @@ module.exports = {
       downloadOpts.arch = 'arm'
     }
     debug(`Downloading Electron with options ${JSON.stringify(downloadOpts)}`)
-    return promisify(download)(downloadOpts)
+    return downloadArtifact(downloadOpts)
   }
 }

--- a/src/targets.js
+++ b/src/targets.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const common = require('./common')
-const hostArch = require('electron-download/lib/arch').host
+const { getHostArch } = require('@electron/get')
 const semver = require('semver')
 
 const officialArchs = ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el']
@@ -61,7 +61,7 @@ function unsupportedListOption (name, value, supported) {
 }
 
 function usingOfficialElectronPackages (opts) {
-  return !opts.download || !opts.download.hasOwnProperty('mirror')
+  return !opts.download || !opts.download.hasOwnProperty('mirrorOptions')
 }
 
 function validOfficialPlatformArch (opts, platform, arch) {
@@ -107,7 +107,7 @@ module.exports = {
     let list = opts[name]
     if (!list) {
       if (name === 'arch') {
-        list = hostArch()
+        list = getHostArch()
       } else {
         list = process[name]
       }

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -34,9 +34,9 @@ async function downloadAll (version) {
 async function downloadElectronZip (version, options) {
   return download.downloadElectronZip({
     ...options,
-    cache: path.join(os.homedir(), '.electron'),
-    quiet: !!process.env.CI,
-    version: version
+    artifactName: 'electron',
+    cacheRoot: path.join(os.homedir(), '.electron'),
+    version
   })
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,7 +3,7 @@
 const common = require('../src/common')
 const download = require('../src/download')
 const fs = require('fs-extra')
-const hostArch = require('electron-download/lib/arch').host
+const { getHostArch } = require('@electron/get')
 const packager = require('..')
 const path = require('path')
 const sinon = require('sinon')
@@ -31,18 +31,19 @@ test('setting the quiet option does not print messages', t => {
   t.true(console.error.notCalled, 'quieted common.info should not call console.error')
 })
 
-test('download argument test: download.{arch,platform,version} does not overwrite {arch,platform,version}', t => {
+test('download argument test: download.{arch,platform,version,artifactName} does not overwrite {arch,platform,version,artifactName}', t => {
   const opts = {
     download: {
       arch: 'ia32',
       platform: 'win32',
-      version: '0.30.0'
+      version: '0.30.0',
+      artifactName: 'ffmpeg'
     },
     electronVersion: '0.36.0'
   }
 
   const downloadOpts = download.createDownloadOpts(opts, 'linux', 'x64')
-  t.deepEqual(downloadOpts, { arch: 'x64', platform: 'linux', version: '0.36.0' })
+  t.deepEqual(downloadOpts, { arch: 'x64', platform: 'linux', version: '0.36.0', artifactName: 'electron' })
 })
 
 test('sanitize app name for use in file/directory names', t => {
@@ -98,7 +99,7 @@ test.serial('defaults', util.testSinglePlatform(async (t, opts) => {
   delete opts.arch
 
   const defaultOpts = {
-    arch: hostArch(),
+    arch: getHostArch(),
     name: opts.name,
     platform: process.platform
   }

--- a/test/cli.js
+++ b/test/cli.js
@@ -10,9 +10,9 @@ test('CLI argument test: --electron-version populates opts.electronVersion', t =
   t.is(args.electronVersion, '1.2.3')
 })
 
-test('CLI argument test: --download.strictSSL default', t => {
+test('CLI argument test: --download.rejectUnauthorized default', t => {
   const args = cli.parseArgs([])
-  t.true(args.download.strictSSL, 'default for --download.strictSSL is true')
+  t.true(args.download.rejectUnauthorized, 'default for --download.rejectUnauthorized is true')
 })
 
 test('CLI argument test: --asar=true', t => {

--- a/test/targets.js
+++ b/test/targets.js
@@ -106,7 +106,7 @@ test('platform=linux and arch=arm64 with an unsupported official Electron versio
 test('platform=linux and arch=mips64el with a supported official Electron version', testMultiTarget({ arch: 'mips64el', platform: 'linux', electronVersion: '1.8.2-beta.5' }, 1, 'Package should be generated for mips64el'))
 test('platform=linux and arch=mips64el with an unsupported official Electron version', testMultiTarget({ arch: 'mips64el', platform: 'linux' }, 0, 'Package should not be generated for mips64el'))
 test('platform=linux and arch=mips64el with an unsupported official Electron version (2.0.0)', testMultiTarget({ arch: 'mips64el', platform: 'linux', electronVersion: '2.0.0' }, 0, 'Package should not be generated for mips64el'))
-test('unofficial arch', testMultiTarget({ arch: 'z80', platform: 'linux', download: { mirror: 'mirror' } }, 1,
+test('unofficial arch', testMultiTarget({ arch: 'z80', platform: 'linux', download: { mirrorOptions: { mirror: 'mirror' } } }, 1,
                                         'Package should be generated for non-standard arch from non-official mirror'))
-test('unofficial platform', testMultiTarget({ arch: 'ia32', platform: 'minix', download: { mirror: 'mirror' } }, 1,
+test('unofficial platform', testMultiTarget({ arch: 'ia32', platform: 'minix', download: { mirrorOptions: { mirror: 'mirror' } } }, 1,
                                             'Package should be generated for non-standard platform from non-official mirror'))

--- a/usage.txt
+++ b/usage.txt
@@ -36,13 +36,16 @@ asar               whether to package the source code within your app into an ar
                    - unpackDir: unpacks the dir to the app.asar.unpacked directory whose names glob
                      pattern or exactly match this string. It's relative to the <sourcedir>.
 build-version      build version to set for the app
-download           a list of sub-options to pass to electron-download. They are specified via dot
-                   notation, e.g., --download.cache=/tmp/cache
+download           a list of sub-options to pass to @electron/get. They are specified via dot
+                   notation, e.g., --download.cacheRoot=/tmp/cache
                    Properties supported:
-                   - cache: directory of cached Electron downloads. Defaults to `$HOME/.electron`
-                   - mirror: alternate URL to download Electron zips
-                   - strictSSL: whether SSL certs are required to be valid when downloading
-                     Electron. Defaults to true, use --no-download.strictSSL to disable checks.
+                   - cacheRoot: directory of cached Electron downloads. For default value, see
+                     @electron/get documentation
+                   - mirrorOptions: alternate URL options for downloading Electron zips. See
+                     @electron/get documentation for details
+                   - rejectUnauthorized: whether SSL certs are required to be valid when downloading
+                     Electron. Defaults to true, use --no-download.rejectUnauthorized to disable
+                     checks.
 electron-version   the version of Electron that is being packaged, see
                    https://github.com/electron/electron/releases
 executable-name    the name of the executable file, sans file extension. Defaults to appname


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

BREAKING CHANGE: The download options are completely different.

Depends on:
* https://github.com/electron/get/pull/94 (debug support)
* https://github.com/electron/get/pull/93, somewhat (docs support, need to link to a place where all of the options are enumerated)