### PR TITLE
Remove section from README about 'Open Open Source'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,12 +34,6 @@ application is approximately the same size as the zipped prebuilt binary for a g
 platform, target arch, and [Electron version](https://github.com/electron/electron/releases)
 _(files named `electron-v${version}-${platform}-${arch}.zip`)_.
 
-### Electron Packager is an [OPEN Open Source Project](http://openopensource.org/)
-
-Individuals making significant and valuable contributions are given commit-access to the project to contribute as they see fit. This project is more like an open wiki than a standard guarded open source project.
-
-See [CONTRIBUTING.md](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) and [openopensource.org](http://openopensource.org/) for more details.
-
 ## Supported Platforms
 
 Electron Packager is known to run on the following **host** platforms:


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This project has been officially declared as an "open open source" project for the past 3 years, although it's informally been like that for much longer. Unfortunately, with events like the [`event-stream` incident](https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident) happening, we need to rethink how we want to handle contributions. This is an important package in the Electron ecosystem, and it should be protected as such. Ultimately, I've decided to revert back to a more traditional maintainership model: if you'd like to be a maintainer of this project, you'll need to show that you'll do the work necessary for the role, whether it's triaging issues, submitting features/bug fixes, or enhancing the documentation.